### PR TITLE
[FEAT] 세션 기반 인증 및 권한 인프라, 로그아웃 기능 구현

### DIFF
--- a/src/main/kotlin/com/dh/baro/core/AggregateRoot.kt
+++ b/src/main/kotlin/com/dh/baro/core/AggregateRoot.kt
@@ -1,4 +1,4 @@
-package com.dh.baro.core.annotation
+package com.dh.baro.core
 
 @Target(AnnotationTarget.CLASS)
 @Retention(AnnotationRetention.RUNTIME)

--- a/src/main/kotlin/com/dh/baro/core/ErrorMessage.kt
+++ b/src/main/kotlin/com/dh/baro/core/ErrorMessage.kt
@@ -3,8 +3,10 @@ package com.dh.baro.core
 enum class ErrorMessage(val message: String) {
 
     // Common
-    UNHANDLED_EXCEPTION("서버 오류가 발생했습니다. 관리자에게 문의해주세요."),
+    UNAUTHORIZED("로그인이 필요합니다."),
+    FORBIDDEN("권한이 없습니다."),
     NO_RESOURCE_FOUND("요청한 리소스를 찾을 수 없습니다."),
+    UNHANDLED_EXCEPTION("서버 오류가 발생했습니다. 관리자에게 문의해주세요."),
 
     // Identity
     UNSUPPORTED_SOCIAL_LOGIN("지원하지 않는 소셜 로그인 제공자입니다: %s"),

--- a/src/main/kotlin/com/dh/baro/core/advice/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/com/dh/baro/core/advice/GlobalExceptionHandler.kt
@@ -31,7 +31,7 @@ class GlobalExceptionHandler {
 
     @ResponseStatus(HttpStatus.FORBIDDEN)
     @ExceptionHandler(ForbiddenException::class)
-    fun handleUnauthorizedException(exception: ForbiddenException): ErrorResponse {
+    fun handleForbiddenException(exception: ForbiddenException): ErrorResponse {
         logger.warn("[Forbidden] : ${exception.message}", exception)
         return ErrorResponse.from(exception)
     }

--- a/src/main/kotlin/com/dh/baro/core/advice/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/com/dh/baro/core/advice/GlobalExceptionHandler.kt
@@ -2,9 +2,10 @@ package com.dh.baro.core.advice
 
 import com.dh.baro.core.ErrorMessage
 import com.dh.baro.core.ErrorResponse
+import com.dh.baro.core.exception.ForbiddenException
+import com.dh.baro.core.exception.UnauthorizedException
 import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus
-import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.MissingRequestHeaderException
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.ResponseStatus
@@ -25,6 +26,20 @@ class GlobalExceptionHandler {
     @ExceptionHandler(IllegalArgumentException::class)
     fun handleIllegalArgumentException(exception: IllegalArgumentException): ErrorResponse {
         logger.info(exception.message, exception)
+        return ErrorResponse.from(exception)
+    }
+
+    @ResponseStatus(HttpStatus.FORBIDDEN)
+    @ExceptionHandler(ForbiddenException::class)
+    fun handleUnauthorizedException(exception: ForbiddenException): ErrorResponse {
+        logger.warn("[Forbidden] : ${exception.message}", exception)
+        return ErrorResponse.from(exception)
+    }
+
+    @ResponseStatus(HttpStatus.UNAUTHORIZED)
+    @ExceptionHandler(UnauthorizedException::class)
+    fun handleUnauthorizedException(exception: UnauthorizedException): ErrorResponse {
+        logger.warn("[Unauthorized] : ${exception.message}", exception)
         return ErrorResponse.from(exception)
     }
 

--- a/src/main/kotlin/com/dh/baro/core/auth/Authenticated.kt
+++ b/src/main/kotlin/com/dh/baro/core/auth/Authenticated.kt
@@ -1,0 +1,9 @@
+package com.dh.baro.core.auth
+
+import com.dh.baro.identity.domain.MemberRole
+
+@Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class Authenticated(
+    val roles: Array<MemberRole> = emptyArray()
+)

--- a/src/main/kotlin/com/dh/baro/core/auth/AuthenticationAspect.kt
+++ b/src/main/kotlin/com/dh/baro/core/auth/AuthenticationAspect.kt
@@ -1,12 +1,12 @@
 package com.dh.baro.core.auth
 
 import com.dh.baro.core.ErrorMessage
+import com.dh.baro.core.exception.ForbiddenException
 import org.aspectj.lang.ProceedingJoinPoint
 import org.aspectj.lang.annotation.Around
 import org.aspectj.lang.annotation.Aspect
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
-import java.nio.file.AccessDeniedException
 
 @Aspect
 @Component
@@ -21,7 +21,7 @@ class AuthenticationAspect(
         if (auth.roles.isNotEmpty()) {
             val role = sessionManager.getCurrentMemberRole()
             if (role !in auth.roles) {
-                throw AccessDeniedException(ErrorMessage.FORBIDDEN.message)
+                throw ForbiddenException(ErrorMessage.FORBIDDEN.message)
             }
         }
 

--- a/src/main/kotlin/com/dh/baro/core/auth/AuthenticationAspect.kt
+++ b/src/main/kotlin/com/dh/baro/core/auth/AuthenticationAspect.kt
@@ -1,0 +1,30 @@
+package com.dh.baro.core.auth
+
+import com.dh.baro.core.ErrorMessage
+import org.aspectj.lang.ProceedingJoinPoint
+import org.aspectj.lang.annotation.Around
+import org.aspectj.lang.annotation.Aspect
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+import java.nio.file.AccessDeniedException
+
+@Aspect
+@Component
+class AuthenticationAspect(
+    private val sessionManager: SessionManager
+) {
+
+    @Around("@within(auth) || @annotation(auth)")
+    @Transactional(readOnly = true)
+    fun checkAuthentication(joinPoint: ProceedingJoinPoint, auth: Authenticated): Any? {
+        sessionManager.getCurrentMemberId()
+        if (auth.roles.isNotEmpty()) {
+            val role = sessionManager.getCurrentMemberRole()
+            if (role !in auth.roles) {
+                throw AccessDeniedException(ErrorMessage.FORBIDDEN.message)
+            }
+        }
+
+        return joinPoint.proceed()
+    }
+}

--- a/src/main/kotlin/com/dh/baro/core/auth/CurrentUser.kt
+++ b/src/main/kotlin/com/dh/baro/core/auth/CurrentUser.kt
@@ -1,0 +1,5 @@
+package com.dh.baro.core.auth
+
+@Target(AnnotationTarget.VALUE_PARAMETER)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class CurrentUser

--- a/src/main/kotlin/com/dh/baro/core/auth/CurrentUserArgumentResolver.kt
+++ b/src/main/kotlin/com/dh/baro/core/auth/CurrentUserArgumentResolver.kt
@@ -1,0 +1,27 @@
+package com.dh.baro.core.auth
+
+import org.springframework.core.MethodParameter
+import org.springframework.stereotype.Component
+import org.springframework.web.bind.support.WebDataBinderFactory
+import org.springframework.web.context.request.NativeWebRequest
+import org.springframework.web.method.support.HandlerMethodArgumentResolver
+import org.springframework.web.method.support.ModelAndViewContainer
+
+@Component
+class CurrentUserArgumentResolver(
+    private val sessionManager: SessionManager
+) : HandlerMethodArgumentResolver {
+
+    override fun supportsParameter(parameter: MethodParameter): Boolean =
+        parameter.getParameterAnnotation(CurrentUser::class.java) != null
+                && parameter.parameterType == Long::class.java
+
+    override fun resolveArgument(
+        parameter: MethodParameter,
+        mavContainer: ModelAndViewContainer?,
+        webRequest: NativeWebRequest,
+        binderFactory: WebDataBinderFactory?
+    ): Any {
+        return sessionManager.getCurrentMemberId()
+    }
+}

--- a/src/main/kotlin/com/dh/baro/core/auth/SessionKeys.kt
+++ b/src/main/kotlin/com/dh/baro/core/auth/SessionKeys.kt
@@ -1,0 +1,6 @@
+package com.dh.baro.core.auth
+
+object SessionKeys {
+    const val MEMBER_ID = "MEMBER_ID"
+    const val MEMBER_ROLE = "MEMBER_ROLE"
+}

--- a/src/main/kotlin/com/dh/baro/core/auth/SessionManager.kt
+++ b/src/main/kotlin/com/dh/baro/core/auth/SessionManager.kt
@@ -1,0 +1,23 @@
+package com.dh.baro.core.auth
+
+import com.dh.baro.core.ErrorMessage
+import com.dh.baro.core.exception.UnauthorizedException
+import com.dh.baro.identity.domain.MemberRole
+import jakarta.servlet.http.HttpServletRequest
+import org.springframework.stereotype.Component
+
+@Component
+class SessionManager(
+    private val request: HttpServletRequest
+) {
+
+    fun getCurrentMemberId(): Long =
+        request.getSession(false)
+            ?.getAttribute(SessionKeys.MEMBER_ID) as? Long
+            ?: throw UnauthorizedException(ErrorMessage.UNAUTHORIZED.message)
+
+    fun getCurrentMemberRole(): MemberRole =
+        request.getSession(false)
+            ?.getAttribute(SessionKeys.MEMBER_ROLE) as? MemberRole
+            ?: throw UnauthorizedException(ErrorMessage.UNAUTHORIZED.message)
+}

--- a/src/main/kotlin/com/dh/baro/core/config/WebConfig.kt
+++ b/src/main/kotlin/com/dh/baro/core/config/WebConfig.kt
@@ -1,11 +1,19 @@
 package com.dh.baro.core.config
 
+import com.dh.baro.core.auth.CurrentUserArgumentResolver
 import org.springframework.context.annotation.Configuration
+import org.springframework.web.method.support.HandlerMethodArgumentResolver
 import org.springframework.web.servlet.config.annotation.CorsRegistry
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
 
 @Configuration
-internal class CorsConfig : WebMvcConfigurer {
+internal class WebConfig(
+    private val currentUserArgumentResolver: CurrentUserArgumentResolver
+) : WebMvcConfigurer {
+
+    override fun addArgumentResolvers(resolvers: MutableList<HandlerMethodArgumentResolver>) {
+        resolvers.add(currentUserArgumentResolver)
+    }
 
     override fun addCorsMappings(registry: CorsRegistry) {
         registry.addMapping("/**")

--- a/src/main/kotlin/com/dh/baro/core/exception/ForbiddenException.kt
+++ b/src/main/kotlin/com/dh/baro/core/exception/ForbiddenException.kt
@@ -1,0 +1,3 @@
+package com.dh.baro.core.exception
+
+class ForbiddenException(message: String): RuntimeException(message)

--- a/src/main/kotlin/com/dh/baro/core/exception/UnauthorizedException.kt
+++ b/src/main/kotlin/com/dh/baro/core/exception/UnauthorizedException.kt
@@ -1,0 +1,3 @@
+package com.dh.baro.core.exception
+
+class UnauthorizedException(message: String) : RuntimeException(message)

--- a/src/main/kotlin/com/dh/baro/identity/application/AuthFacade.kt
+++ b/src/main/kotlin/com/dh/baro/identity/application/AuthFacade.kt
@@ -4,7 +4,6 @@ import com.dh.baro.identity.application.dto.AuthResult
 import com.dh.baro.identity.domain.*
 import com.dh.baro.identity.domain.service.MemberService
 import org.springframework.stereotype.Service
-import org.springframework.transaction.annotation.Transactional
 
 @Service
 class AuthFacade(
@@ -12,11 +11,10 @@ class AuthFacade(
     private val memberService: MemberService,
 ) {
 
-    @Transactional
     fun login(provider: AuthProvider, accessToken: String): AuthResult {
         val oauthApi = oauthApiFactory.getClient(provider)
         val socialUserInfo = oauthApi.fetchUser(accessToken)
         val response = memberService.findOrRegister(provider, socialUserInfo)
-        return AuthResult(response.member.id, response.isNew)
+        return AuthResult(response.memberId, response.memberRole, response.isNew)
     }
 }

--- a/src/main/kotlin/com/dh/baro/identity/application/dto/AuthResult.kt
+++ b/src/main/kotlin/com/dh/baro/identity/application/dto/AuthResult.kt
@@ -2,5 +2,6 @@ package com.dh.baro.identity.application.dto
 
 data class AuthResult(
     val memberId: Long,
+    val memberRole: String,
     val isNew: Boolean,
 )

--- a/src/main/kotlin/com/dh/baro/identity/application/dto/AuthResult.kt
+++ b/src/main/kotlin/com/dh/baro/identity/application/dto/AuthResult.kt
@@ -1,7 +1,9 @@
 package com.dh.baro.identity.application.dto
 
+import com.dh.baro.identity.domain.MemberRole
+
 data class AuthResult(
     val memberId: Long,
-    val memberRole: String,
+    val memberRole: MemberRole,
     val isNew: Boolean,
 )

--- a/src/main/kotlin/com/dh/baro/identity/domain/Member.kt
+++ b/src/main/kotlin/com/dh/baro/identity/domain/Member.kt
@@ -2,7 +2,7 @@ package com.dh.baro.identity.domain
 
 import com.dh.baro.core.AbstractTime
 import com.dh.baro.core.IdGenerator
-import com.dh.baro.core.annotation.AggregateRoot
+import com.dh.baro.core.AggregateRoot
 import jakarta.persistence.*
 
 @AggregateRoot

--- a/src/main/kotlin/com/dh/baro/identity/domain/dto/RegistrationResult.kt
+++ b/src/main/kotlin/com/dh/baro/identity/domain/dto/RegistrationResult.kt
@@ -2,5 +2,6 @@ package com.dh.baro.identity.domain.dto
 
 data class RegistrationResult(
     val memberId: Long,
+    val memberRole: String,
     val isNew: Boolean,
 )

--- a/src/main/kotlin/com/dh/baro/identity/domain/dto/RegistrationResult.kt
+++ b/src/main/kotlin/com/dh/baro/identity/domain/dto/RegistrationResult.kt
@@ -1,7 +1,9 @@
 package com.dh.baro.identity.domain.dto
 
+import com.dh.baro.identity.domain.MemberRole
+
 data class RegistrationResult(
     val memberId: Long,
-    val memberRole: String,
+    val memberRole: MemberRole,
     val isNew: Boolean,
 )

--- a/src/main/kotlin/com/dh/baro/identity/domain/service/MemberService.kt
+++ b/src/main/kotlin/com/dh/baro/identity/domain/service/MemberService.kt
@@ -21,7 +21,7 @@ class MemberService(
     ): RegistrationResult {
         socialAccountRepository.findByProviderAndProviderId(provider, socialUserInfo.providerId)
             ?.let { existingAccount ->
-                return RegistrationResult(existingAccount.member.id, isNew = false)
+                return RegistrationResult(existingAccount.member.id, existingAccount.member.role.name, isNew = false)
             }
 
         val member = Member.newMember(socialUserInfo.nickname, socialUserInfo.email)
@@ -29,6 +29,6 @@ class MemberService(
         SocialAccount.of(member, provider, socialUserInfo.providerId)
             .let { socialAccount -> socialAccountRepository.save(socialAccount) }
 
-        return RegistrationResult(member.id, isNew = true)
+        return RegistrationResult(member.id, member.role.name, isNew = true)
     }
 }

--- a/src/main/kotlin/com/dh/baro/identity/presentation/AuthController.kt
+++ b/src/main/kotlin/com/dh/baro/identity/presentation/AuthController.kt
@@ -4,7 +4,6 @@ import com.dh.baro.core.auth.SessionKeys.MEMBER_ID
 import com.dh.baro.core.auth.SessionKeys.MEMBER_ROLE
 import com.dh.baro.identity.application.AuthFacade
 import com.dh.baro.identity.application.dto.LoginResponse
-import com.dh.baro.identity.domain.AuthProvider
 import com.dh.baro.identity.presentation.dto.OauthLoginRequest
 import jakarta.servlet.http.HttpServletRequest
 import org.springframework.http.HttpStatus
@@ -31,7 +30,9 @@ class AuthController(
         return LoginResponse(result.isNew)
     }
 
-    companion object SessionKeys {
-        const val MEMBER_ID = "MEMBER_ID"
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @PostMapping("/logout")
+    fun logout(request: HttpServletRequest) {
+        request.session.invalidate()
     }
 }

--- a/src/main/kotlin/com/dh/baro/identity/presentation/AuthController.kt
+++ b/src/main/kotlin/com/dh/baro/identity/presentation/AuthController.kt
@@ -1,5 +1,7 @@
 package com.dh.baro.identity.presentation
 
+import com.dh.baro.core.auth.SessionKeys.MEMBER_ID
+import com.dh.baro.core.auth.SessionKeys.MEMBER_ROLE
 import com.dh.baro.identity.application.AuthFacade
 import com.dh.baro.identity.application.dto.LoginResponse
 import com.dh.baro.identity.domain.AuthProvider
@@ -21,7 +23,11 @@ class AuthController(
         request: HttpServletRequest
     ): LoginResponse {
         val result = authFacade.login(oauthLoginRequest.provider, oauthLoginRequest.accessToken)
-        request.session.apply { setAttribute(MEMBER_ID, result.memberId) }
+        request.session.apply {
+            setAttribute(MEMBER_ID, result.memberId)
+            setAttribute(MEMBER_ROLE, result.memberRole)
+        }
+
         return LoginResponse(result.isNew)
     }
 

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -2,6 +2,11 @@ server:
   port: 8080
   servlet:
     contextPath:
+    session:
+      cookie:
+        http-only: true
+        secure: true
+        same-site: strict
 
 spring:
   jackson:
@@ -23,6 +28,11 @@ spring:
       port: ${REDIS_PORT}
       timeout: 1s
       password: ${REDIS_PASSWORD}
+
+  session:
+    timeout: 30m
+    redis:
+      flush-mode: on-save
 
   jpa:
     database-platform: org.hibernate.dialect.MySQL8Dialect


### PR DESCRIPTION
## Issue Number
#5 

## As-Is
<!-- Describe the current issue or problem -->
- 인증 정보 없이 컨트롤러에서 사용자 ID를 직접 받거나 세션에서 일일이 추출해야 했음
- 권한 제어 로직이 분산되어 있고 중복 가능성이 높았음
- 인증 실패/인가 실패에 대한 일관된 예외 처리 구조가 부재했음
- 세션 내 역할 정보(MEMBER_ROLE)를 저장하지 않아 AOP 기반 권한 검증이 어려웠음

## To-Be
<!-- Describe the intended changes or improvements -->
* [x] `@Authenticated` 애노테이션을 통한 AOP 기반 인증 및 역할(Role) 권한 체크 기능 도입
* [x] `@CurrentUser` 파라미터 애노테이션 및 `CurrentUserArgumentResolver` 구현을 통해 세션 기반 사용자 ID 주입 자동화
* [x] `SessionManager`를 통한 MEMBER_ID 및 MEMBER_ROLE 추출 로직 중앙화
* [x] 로그인 시 세션에 MEMBER_ROLE 추가 저장
* [x] 로그아웃 시 세션 완전 무효화 처리 (`invalidate`)
* [x] `UnauthorizedException`, `ForbiddenException` 도메인 예외 정의
* [x] `GlobalExceptionHandler`에 인증/인가 예외 핸들러 등록 (401 / 403 응답 일관화)
* [x] `ErrorMessage` enum에 `UNAUTHORIZED`, `FORBIDDEN` 메시지 항목 추가
* [x] `WebConfig`를 통해 리졸버 스프링 MVC에 등록

## ✅ Check List

- [x] Have all tests passed?
- [x] Have all commits been pushed?
- [x] Did you verify the target branch for the merge?
- [x] Did you assign the appropriate assignee(s)?
- [x] Did you set the correct label(s)?

## 📸 Test Screenshot

## Additional Description
