### PR TITLE
[FEAT] 장바구니 CRUD 기능 구현

### DIFF
--- a/src/main/kotlin/com/dh/baro/cart/application/CartFacade.kt
+++ b/src/main/kotlin/com/dh/baro/cart/application/CartFacade.kt
@@ -1,0 +1,29 @@
+package com.dh.baro.cart.application
+
+import com.dh.baro.cart.domain.CartItem
+import com.dh.baro.cart.domain.CartService
+import com.dh.baro.cart.presentation.dto.AddItemRequest
+import org.springframework.stereotype.Service
+
+@Service
+class CartFacade(
+    private val cartService: CartService,
+) {
+
+    fun getCartItems(userId: Long): List<CartItem> =
+        cartService.getItems(userId)
+
+    fun addItem(userId: Long, request: AddItemRequest) {
+        cartService.addItem(
+            userId = userId,
+            productId = request.productId,
+            quantity = request.quantity,
+        )
+    }
+
+    fun updateQuantity(userId: Long, itemId: Long, qty: Int) =
+        cartService.updateItemQuantity(userId, itemId, qty)
+
+    fun removeItem(userId: Long, itemId: Long) =
+        cartService.removeItem(userId, itemId)
+}

--- a/src/main/kotlin/com/dh/baro/cart/domain/CartItem.kt
+++ b/src/main/kotlin/com/dh/baro/cart/domain/CartItem.kt
@@ -37,11 +37,12 @@ class CartItem(
     }
 
     companion object {
-        fun newCartItem(user: User, product: Product): CartItem {
+        fun newCartItem(user: User, product: Product, quantity: Int): CartItem {
             return CartItem(
                 id = IdGenerator.generate(),
                 user = user,
                 product = product,
+                quantity = quantity,
             )
         }
     }

--- a/src/main/kotlin/com/dh/baro/cart/domain/CartItem.kt
+++ b/src/main/kotlin/com/dh/baro/cart/domain/CartItem.kt
@@ -1,14 +1,15 @@
 package com.dh.baro.cart.domain
 
 import com.dh.baro.core.AbstractTime
-import com.dh.baro.identity.domain.Member
+import com.dh.baro.core.IdGenerator
+import com.dh.baro.identity.domain.User
 import com.dh.baro.product.domain.Product
 import jakarta.persistence.*
 
 @Entity
 @Table(
     name = "cart_items",
-    uniqueConstraints = [UniqueConstraint(columnNames = ["member_id", "product_id"])]
+    uniqueConstraints = [UniqueConstraint(columnNames = ["user_id", "product_id"])]
 )
 class CartItem(
     @Id
@@ -16,8 +17,8 @@ class CartItem(
     val id: Long,
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id", nullable = false)
-    val member: Member,
+    @JoinColumn(name = "user_id", nullable = false)
+    val user: User,
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "product_id", nullable = false)
@@ -25,4 +26,23 @@ class CartItem(
 
     @Column(name = "quantity", nullable = false)
     var quantity: Int = 1
-) : AbstractTime()
+) : AbstractTime() {
+
+    fun addQuantity(quantity: Int) {
+        this.quantity += quantity
+    }
+
+    fun changeQuantity(quantity: Int) {
+        this.quantity = quantity
+    }
+
+    companion object {
+        fun newCartItem(user: User, product: Product): CartItem {
+            return CartItem(
+                id = IdGenerator.generate(),
+                user = user,
+                product = product,
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/dh/baro/cart/domain/CartItemRepository.kt
+++ b/src/main/kotlin/com/dh/baro/cart/domain/CartItemRepository.kt
@@ -1,0 +1,16 @@
+package com.dh.baro.cart.domain
+
+import org.springframework.data.jpa.repository.EntityGraph
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface CartItemRepository : JpaRepository<CartItem, Long> {
+
+    @EntityGraph(attributePaths = ["product"])
+    fun findByUserId(userId: Long): List<CartItem>
+
+    fun findByUserIdAndProductId(userId: Long, productId: Long): CartItem?
+
+    fun findByIdAndUserId(id: Long, userId: Long): CartItem?
+
+    fun countByUserId(userId: Long): Long
+}

--- a/src/main/kotlin/com/dh/baro/cart/domain/CartPolicy.kt
+++ b/src/main/kotlin/com/dh/baro/cart/domain/CartPolicy.kt
@@ -1,0 +1,14 @@
+package com.dh.baro.cart.domain
+
+import org.springframework.stereotype.Component
+
+@Component
+class CartPolicy {
+
+    companion object {
+        const val ITEM_LIMIT = 20
+    }
+
+    fun canAddMoreItems(currentCount: Long): Boolean =
+        currentCount < ITEM_LIMIT
+}

--- a/src/main/kotlin/com/dh/baro/cart/domain/CartService.kt
+++ b/src/main/kotlin/com/dh/baro/cart/domain/CartService.kt
@@ -31,7 +31,7 @@ class CartService(
         val product = productRepository.findByIdOrNull(productId)
             ?: throw IllegalArgumentException(ErrorMessage.PRODUCT_NOT_FOUND.format(productId))
 
-        return cartItemRepository.save(CartItem.newCartItem(user, product))
+        return cartItemRepository.save(CartItem.newCartItem(user, product, quantity))
     }
 
     private fun validateCartLimit(userId: Long) {

--- a/src/main/kotlin/com/dh/baro/cart/domain/CartService.kt
+++ b/src/main/kotlin/com/dh/baro/cart/domain/CartService.kt
@@ -1,0 +1,57 @@
+package com.dh.baro.cart.domain
+
+import com.dh.baro.core.ErrorMessage
+import com.dh.baro.identity.domain.repository.UserRepository
+import com.dh.baro.product.domain.ProductRepository
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class CartService(
+    private val cartItemRepository: CartItemRepository,
+    private val userRepository: UserRepository,
+    private val productRepository: ProductRepository,
+    private val cartPolicy: CartPolicy,
+) {
+
+    @Transactional(readOnly = true)
+    fun getItems(userId: Long): List<CartItem> =
+        cartItemRepository.findByUserId(userId)
+
+    @Transactional
+    fun addItem(userId: Long, productId: Long, quantity: Int): CartItem {
+        cartItemRepository.findByUserIdAndProductId(userId, productId)
+            ?.also { it.addQuantity(quantity); return it }
+
+        validateCartLimit(userId)
+
+        val user = userRepository.findByIdOrNull(userId)
+            ?: throw IllegalArgumentException(ErrorMessage.USER_NOT_FOUND.format(userId))
+        val product = productRepository.findByIdOrNull(productId)
+            ?: throw IllegalArgumentException(ErrorMessage.PRODUCT_NOT_FOUND.format(productId))
+
+        return cartItemRepository.save(CartItem.newCartItem(user, product))
+    }
+
+    private fun validateCartLimit(userId: Long) {
+        val currentCnt = cartItemRepository.countByUserId(userId)
+        if (!cartPolicy.canAddMoreItems(currentCnt)) {
+            throw IllegalStateException(ErrorMessage.CART_ITEM_LIMIT_EXCEEDED.message)
+        }
+    }
+
+    @Transactional
+    fun updateItemQuantity(userId: Long, itemId: Long, newQuantity: Int) {
+        val item = cartItemRepository.findByIdAndUserId(itemId, userId)
+            ?: throw IllegalArgumentException(ErrorMessage.CART_ITEM_NOT_FOUND.format(itemId))
+        item.changeQuantity(newQuantity)
+    }
+
+    @Transactional
+    fun removeItem(userId: Long, itemId: Long) {
+        val item = cartItemRepository.findByIdAndUserId(itemId, userId)
+            ?: throw IllegalArgumentException(ErrorMessage.CART_ITEM_NOT_FOUND.format(itemId))
+        cartItemRepository.delete(item)
+    }
+}

--- a/src/main/kotlin/com/dh/baro/cart/presentation/CartController.kt
+++ b/src/main/kotlin/com/dh/baro/cart/presentation/CartController.kt
@@ -4,17 +4,18 @@ import com.dh.baro.cart.application.CartFacade
 import com.dh.baro.cart.presentation.dto.AddItemRequest
 import com.dh.baro.cart.presentation.dto.CartResponse
 import com.dh.baro.cart.presentation.dto.UpdateQuantityRequest
-import com.dh.baro.core.auth.Authenticated
+import com.dh.baro.core.auth.RequireAuth
 import com.dh.baro.core.auth.CurrentUser
+import com.dh.baro.identity.domain.UserRole
 import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.*
 
 @RestController
 @RequestMapping("/cart")
-@Authenticated
+@RequireAuth(UserRole.BUYER)
 class CartController(
-    private val cartFacade: CartFacade
+    private val cartFacade: CartFacade,
 ) {
 
     @GetMapping

--- a/src/main/kotlin/com/dh/baro/cart/presentation/CartController.kt
+++ b/src/main/kotlin/com/dh/baro/cart/presentation/CartController.kt
@@ -1,0 +1,46 @@
+package com.dh.baro.cart.presentation
+
+import com.dh.baro.cart.application.CartFacade
+import com.dh.baro.cart.presentation.dto.AddItemRequest
+import com.dh.baro.cart.presentation.dto.CartResponse
+import com.dh.baro.cart.presentation.dto.UpdateQuantityRequest
+import com.dh.baro.core.auth.Authenticated
+import com.dh.baro.core.auth.CurrentUser
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.*
+
+@RestController
+@RequestMapping("/cart")
+@Authenticated
+class CartController(
+    private val cartFacade: CartFacade
+) {
+
+    @GetMapping
+    @ResponseStatus(HttpStatus.OK)
+    fun getCart(@CurrentUser userId: Long): CartResponse =
+        CartResponse.from(cartFacade.getCartItems(userId))
+
+    @PostMapping("/items")
+    @ResponseStatus(HttpStatus.CREATED)
+    fun addItem(
+        @CurrentUser userId: Long,
+        @Valid @RequestBody request: AddItemRequest,
+    ) = cartFacade.addItem(userId, request)
+
+    @PatchMapping("/items/{itemId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    fun updateQuantity(
+        @CurrentUser userId: Long,
+        @PathVariable itemId: Long,
+        @Valid @RequestBody request: UpdateQuantityRequest,
+    ) = cartFacade.updateQuantity(userId, itemId, request.quantity)
+    
+    @DeleteMapping("/items/{itemId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    fun removeItem(
+        @CurrentUser userId: Long,
+        @PathVariable itemId: Long,
+    ) = cartFacade.removeItem(userId, itemId)
+}

--- a/src/main/kotlin/com/dh/baro/cart/presentation/dto/AddItemRequest.kt
+++ b/src/main/kotlin/com/dh/baro/cart/presentation/dto/AddItemRequest.kt
@@ -1,0 +1,11 @@
+package com.dh.baro.cart.presentation.dto
+
+import jakarta.validation.constraints.Min
+import jakarta.validation.constraints.Positive
+
+data class AddItemRequest(
+    @field:Positive(message = "유효한 상품 ID를 입력해주세요.")
+    val productId: Long,
+    @field:Min(value = 1, message = "수량은 1개 이상이어야 합니다.")
+    val quantity: Int,
+)

--- a/src/main/kotlin/com/dh/baro/cart/presentation/dto/CartItemResponse.kt
+++ b/src/main/kotlin/com/dh/baro/cart/presentation/dto/CartItemResponse.kt
@@ -1,0 +1,13 @@
+package com.dh.baro.cart.presentation.dto
+
+import java.math.BigDecimal
+
+data class CartItemResponse(
+    val itemId: Long,
+    val productId: Long,
+    val productName: String,
+    val productImageUrl: String?,
+    val price: BigDecimal,
+    val quantity: Int,
+    val subtotal: BigDecimal,
+)

--- a/src/main/kotlin/com/dh/baro/cart/presentation/dto/CartResponse.kt
+++ b/src/main/kotlin/com/dh/baro/cart/presentation/dto/CartResponse.kt
@@ -2,15 +2,19 @@ package com.dh.baro.cart.presentation.dto
 
 import com.dh.baro.cart.domain.CartItem
 import java.math.BigDecimal
+import java.math.RoundingMode
 
 data class CartResponse(
     val items: List<CartItemResponse>,
     val totalPrice: BigDecimal
 ) {
     companion object {
+        private const val SCALE_NONE = 0
+
         fun from(cartItems: List<CartItem>): CartResponse {
             val responses = cartItems.map { it.toResponse() }
             val total = responses.fold(BigDecimal.ZERO) { sum, item -> sum + item.subtotal }
+                .setScale(SCALE_NONE, RoundingMode.HALF_UP)
             return CartResponse(responses, total)
         }
 
@@ -21,7 +25,9 @@ data class CartResponse(
             productImageUrl = product.getThumbnailUrl(),
             price = product.price,
             quantity = quantity,
-            subtotal = product.price * BigDecimal(quantity)
+            subtotal = product.price
+                .multiply(BigDecimal(quantity))
+                .setScale(SCALE_NONE, RoundingMode.HALF_UP)
         )
     }
 }

--- a/src/main/kotlin/com/dh/baro/cart/presentation/dto/CartResponse.kt
+++ b/src/main/kotlin/com/dh/baro/cart/presentation/dto/CartResponse.kt
@@ -1,0 +1,27 @@
+package com.dh.baro.cart.presentation.dto
+
+import com.dh.baro.cart.domain.CartItem
+import java.math.BigDecimal
+
+data class CartResponse(
+    val items: List<CartItemResponse>,
+    val totalPrice: BigDecimal
+) {
+    companion object {
+        fun from(cartItems: List<CartItem>): CartResponse {
+            val responses = cartItems.map { it.toResponse() }
+            val total = responses.fold(BigDecimal.ZERO) { sum, item -> sum + item.subtotal }
+            return CartResponse(responses, total)
+        }
+
+        private fun CartItem.toResponse() = CartItemResponse(
+            itemId = id,
+            productId = product.id,
+            productName = product.name,
+            productImageUrl = product.getThumbnailUrl(),
+            price = product.price,
+            quantity = quantity,
+            subtotal = product.price * BigDecimal(quantity)
+        )
+    }
+}

--- a/src/main/kotlin/com/dh/baro/cart/presentation/dto/UpdateQuantityRequest.kt
+++ b/src/main/kotlin/com/dh/baro/cart/presentation/dto/UpdateQuantityRequest.kt
@@ -1,0 +1,8 @@
+package com.dh.baro.cart.presentation.dto
+
+import jakarta.validation.constraints.Min
+
+data class UpdateQuantityRequest(
+    @field:Min(value = 1, message = "수량은 1개 이상이어야 합니다.")
+    val quantity: Int,
+)

--- a/src/main/kotlin/com/dh/baro/core/ErrorMessage.kt
+++ b/src/main/kotlin/com/dh/baro/core/ErrorMessage.kt
@@ -9,8 +9,16 @@ enum class ErrorMessage(val message: String) {
     UNHANDLED_EXCEPTION("서버 오류가 발생했습니다. 관리자에게 문의해주세요."),
 
     // Identity
+    USER_NOT_FOUND("사용자를 찾을 수 없습니다: %d"),
     UNSUPPORTED_SOCIAL_LOGIN("지원하지 않는 소셜 로그인 제공자입니다: %s"),
     KAKAO_USER_FETCH_FAILED("카카오 사용자 정보 조회 실패: %s"),
+
+    // Product
+    PRODUCT_NOT_FOUND("상품을 찾을 수 없습니다: %d"),
+
+    //Cart
+    CART_ITEM_NOT_FOUND("장바구니 항목을 찾을 수 없습니다: %d"),
+    CART_ITEM_LIMIT_EXCEEDED("장바구니에는 최대 20개의 상품만 담을 수 있습니다."),
     ;
 
     fun format(vararg args: Any): String =

--- a/src/main/kotlin/com/dh/baro/core/auth/Authenticated.kt
+++ b/src/main/kotlin/com/dh/baro/core/auth/Authenticated.kt
@@ -1,9 +1,9 @@
 package com.dh.baro.core.auth
 
-import com.dh.baro.identity.domain.MemberRole
+import com.dh.baro.identity.domain.UserRole
 
 @Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION)
 @Retention(AnnotationRetention.RUNTIME)
 annotation class Authenticated(
-    val roles: Array<MemberRole> = emptyArray()
+    val roles: Array<UserRole> = []
 )

--- a/src/main/kotlin/com/dh/baro/core/auth/AuthenticationAspect.kt
+++ b/src/main/kotlin/com/dh/baro/core/auth/AuthenticationAspect.kt
@@ -17,9 +17,9 @@ class AuthenticationAspect(
     @Around("@within(auth) || @annotation(auth)")
     @Transactional(readOnly = true)
     fun checkAuthentication(joinPoint: ProceedingJoinPoint, auth: Authenticated): Any? {
-        sessionManager.getCurrentMemberId()
+        sessionManager.getCurrentUserId()
         if (auth.roles.isNotEmpty()) {
-            val role = sessionManager.getCurrentMemberRole()
+            val role = sessionManager.getCurrentUserRole()
             if (role !in auth.roles) {
                 throw ForbiddenException(ErrorMessage.FORBIDDEN.message)
             }

--- a/src/main/kotlin/com/dh/baro/core/auth/AuthenticationAspect.kt
+++ b/src/main/kotlin/com/dh/baro/core/auth/AuthenticationAspect.kt
@@ -16,7 +16,7 @@ class AuthenticationAspect(
 
     @Around("@within(auth) || @annotation(auth)")
     @Transactional(readOnly = true)
-    fun checkAuthentication(joinPoint: ProceedingJoinPoint, auth: Authenticated): Any? {
+    fun checkAuthentication(joinPoint: ProceedingJoinPoint, auth: RequireAuth): Any? {
         sessionManager.getCurrentUserId()
         if (auth.roles.isNotEmpty()) {
             val role = sessionManager.getCurrentUserRole()

--- a/src/main/kotlin/com/dh/baro/core/auth/CurrentUserArgumentResolver.kt
+++ b/src/main/kotlin/com/dh/baro/core/auth/CurrentUserArgumentResolver.kt
@@ -21,7 +21,5 @@ class CurrentUserArgumentResolver(
         mavContainer: ModelAndViewContainer?,
         webRequest: NativeWebRequest,
         binderFactory: WebDataBinderFactory?
-    ): Any {
-        return sessionManager.getCurrentMemberId()
-    }
+    ): Any = sessionManager.getCurrentUserId()
 }

--- a/src/main/kotlin/com/dh/baro/core/auth/RequireAuth.kt
+++ b/src/main/kotlin/com/dh/baro/core/auth/RequireAuth.kt
@@ -4,6 +4,6 @@ import com.dh.baro.identity.domain.UserRole
 
 @Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION)
 @Retention(AnnotationRetention.RUNTIME)
-annotation class Authenticated(
-    val roles: Array<UserRole> = []
+annotation class RequireAuth(
+    vararg val roles: UserRole = []
 )

--- a/src/main/kotlin/com/dh/baro/core/auth/SessionKeys.kt
+++ b/src/main/kotlin/com/dh/baro/core/auth/SessionKeys.kt
@@ -1,6 +1,6 @@
 package com.dh.baro.core.auth
 
 object SessionKeys {
-    const val MEMBER_ID = "MEMBER_ID"
-    const val MEMBER_ROLE = "MEMBER_ROLE"
+    const val USER_ID = "USER_ID"
+    const val USER_ROLE = "USER_ROLE"
 }

--- a/src/main/kotlin/com/dh/baro/core/auth/SessionManager.kt
+++ b/src/main/kotlin/com/dh/baro/core/auth/SessionManager.kt
@@ -2,7 +2,7 @@ package com.dh.baro.core.auth
 
 import com.dh.baro.core.ErrorMessage
 import com.dh.baro.core.exception.UnauthorizedException
-import com.dh.baro.identity.domain.MemberRole
+import com.dh.baro.identity.domain.UserRole
 import jakarta.servlet.http.HttpServletRequest
 import org.springframework.stereotype.Component
 
@@ -11,13 +11,13 @@ class SessionManager(
     private val request: HttpServletRequest
 ) {
 
-    fun getCurrentMemberId(): Long =
+    fun getCurrentUserId(): Long =
         request.getSession(false)
-            ?.getAttribute(SessionKeys.MEMBER_ID) as? Long
+            ?.getAttribute(SessionKeys.USER_ID) as? Long
             ?: throw UnauthorizedException(ErrorMessage.UNAUTHORIZED.message)
 
-    fun getCurrentMemberRole(): MemberRole =
+    fun getCurrentUserRole(): UserRole =
         request.getSession(false)
-            ?.getAttribute(SessionKeys.MEMBER_ROLE) as? MemberRole
+            ?.getAttribute(SessionKeys.USER_ROLE) as? UserRole
             ?: throw UnauthorizedException(ErrorMessage.UNAUTHORIZED.message)
 }

--- a/src/main/kotlin/com/dh/baro/core/exception/ForbiddenException.kt
+++ b/src/main/kotlin/com/dh/baro/core/exception/ForbiddenException.kt
@@ -1,3 +1,3 @@
 package com.dh.baro.core.exception
 
-class ForbiddenException(message: String): RuntimeException(message)
+class ForbiddenException(message: String) : RuntimeException(message)

--- a/src/main/kotlin/com/dh/baro/identity/application/AuthFacade.kt
+++ b/src/main/kotlin/com/dh/baro/identity/application/AuthFacade.kt
@@ -2,19 +2,19 @@ package com.dh.baro.identity.application
 
 import com.dh.baro.identity.application.dto.AuthResult
 import com.dh.baro.identity.domain.*
-import com.dh.baro.identity.domain.service.MemberService
+import com.dh.baro.identity.domain.service.UserService
 import org.springframework.stereotype.Service
 
 @Service
 class AuthFacade(
     private val oauthApiFactory: OauthApiFactory,
-    private val memberService: MemberService,
+    private val userService: UserService,
 ) {
 
     fun login(provider: AuthProvider, accessToken: String): AuthResult {
         val oauthApi = oauthApiFactory.getClient(provider)
         val socialUserInfo = oauthApi.fetchUser(accessToken)
-        val response = memberService.findOrRegister(provider, socialUserInfo)
-        return AuthResult(response.memberId, response.memberRole, response.isNew)
+        val response = userService.findOrRegister(provider, socialUserInfo)
+        return AuthResult(response.userId, response.userRole, response.isNew)
     }
 }

--- a/src/main/kotlin/com/dh/baro/identity/application/dto/AuthResult.kt
+++ b/src/main/kotlin/com/dh/baro/identity/application/dto/AuthResult.kt
@@ -1,9 +1,9 @@
 package com.dh.baro.identity.application.dto
 
-import com.dh.baro.identity.domain.MemberRole
+import com.dh.baro.identity.domain.UserRole
 
 data class AuthResult(
-    val memberId: Long,
-    val memberRole: MemberRole,
+    val userId: Long,
+    val userRole: UserRole,
     val isNew: Boolean,
 )

--- a/src/main/kotlin/com/dh/baro/identity/domain/SocialAccount.kt
+++ b/src/main/kotlin/com/dh/baro/identity/domain/SocialAccount.kt
@@ -15,8 +15,8 @@ class SocialAccount(
     val id: Long,
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id", nullable = false)
-    val member: Member,
+    @JoinColumn(name = "user_id", nullable = false)
+    val user: User,
 
     @Enumerated(EnumType.STRING)
     @Column(name = "provider", nullable = false, length = 30)
@@ -27,10 +27,10 @@ class SocialAccount(
 ) : AbstractTime() {
 
     companion object {
-        fun of(member: Member, provider: AuthProvider, providerId: String): SocialAccount {
+        fun of(user: User, provider: AuthProvider, providerId: String): SocialAccount {
             return SocialAccount(
                 id = IdGenerator.generate(),
-                member = member,
+                user = user,
                 provider = provider,
                 providerId = providerId,
             )

--- a/src/main/kotlin/com/dh/baro/identity/domain/User.kt
+++ b/src/main/kotlin/com/dh/baro/identity/domain/User.kt
@@ -7,13 +7,13 @@ import jakarta.persistence.*
 
 @AggregateRoot
 @Entity
-@Table(name = "members")
-class Member(
+@Table(name = "users")
+class User(
     @Id
     @Column(name = "id")
     val id: Long,
 
-    @Column(name = "member_name", nullable = false)
+    @Column(name = "user_name", nullable = false)
     private var name: String,
 
     @Column(name = "email", nullable = false, unique = true)
@@ -23,11 +23,11 @@ class Member(
     private var phoneNumber: String? = null,
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "member_role", nullable = false, length = 20)
-    val role: MemberRole = MemberRole.BUYER,
+    @Column(name = "user_role", nullable = false, length = 20)
+    val role: UserRole = UserRole.BUYER,
 
     @OneToMany(
-        mappedBy = "member",
+        mappedBy = "user",
         fetch = FetchType.LAZY,
         cascade = [CascadeType.ALL],
         orphanRemoval = true,
@@ -36,8 +36,8 @@ class Member(
 ) : AbstractTime() {
 
     companion object {
-        fun newMember(name: String, email: String): Member {
-            return Member(
+        fun newMember(name: String, email: String): User {
+            return User(
                 id = IdGenerator.generate(),
                 name = name,
                 email = email,

--- a/src/main/kotlin/com/dh/baro/identity/domain/User.kt
+++ b/src/main/kotlin/com/dh/baro/identity/domain/User.kt
@@ -36,7 +36,7 @@ class User(
 ) : AbstractTime() {
 
     companion object {
-        fun newMember(name: String, email: String): User {
+        fun newUser(name: String, email: String): User {
             return User(
                 id = IdGenerator.generate(),
                 name = name,

--- a/src/main/kotlin/com/dh/baro/identity/domain/UserRole.kt
+++ b/src/main/kotlin/com/dh/baro/identity/domain/UserRole.kt
@@ -1,6 +1,6 @@
 package com.dh.baro.identity.domain
 
-enum class MemberRole {
+enum class UserRole {
     BUYER,
     STORE_OWNER,
     ADMIN,

--- a/src/main/kotlin/com/dh/baro/identity/domain/dto/RegistrationResult.kt
+++ b/src/main/kotlin/com/dh/baro/identity/domain/dto/RegistrationResult.kt
@@ -1,9 +1,9 @@
 package com.dh.baro.identity.domain.dto
 
-import com.dh.baro.identity.domain.MemberRole
+import com.dh.baro.identity.domain.UserRole
 
 data class RegistrationResult(
-    val memberId: Long,
-    val memberRole: MemberRole,
+    val userId: Long,
+    val userRole: UserRole,
     val isNew: Boolean,
 )

--- a/src/main/kotlin/com/dh/baro/identity/domain/repository/MemberRepository.kt
+++ b/src/main/kotlin/com/dh/baro/identity/domain/repository/MemberRepository.kt
@@ -1,9 +1,0 @@
-package com.dh.baro.identity.domain.repository
-
-import com.dh.baro.identity.domain.Member
-import org.springframework.data.jpa.repository.JpaRepository
-import java.util.Optional
-
-interface MemberRepository : JpaRepository<Member, Long> {
-    fun findByEmail(email: String?): Optional<Member>
-}

--- a/src/main/kotlin/com/dh/baro/identity/domain/repository/UserRepository.kt
+++ b/src/main/kotlin/com/dh/baro/identity/domain/repository/UserRepository.kt
@@ -1,0 +1,8 @@
+package com.dh.baro.identity.domain.repository
+
+import com.dh.baro.identity.domain.User
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface UserRepository : JpaRepository<User, Long> {
+    fun findByEmail(email: String): User?
+}

--- a/src/main/kotlin/com/dh/baro/identity/domain/service/UserService.kt
+++ b/src/main/kotlin/com/dh/baro/identity/domain/service/UserService.kt
@@ -3,14 +3,14 @@ package com.dh.baro.identity.domain.service
 import com.dh.baro.identity.application.OauthApi
 import com.dh.baro.identity.domain.*
 import com.dh.baro.identity.domain.dto.RegistrationResult
-import com.dh.baro.identity.domain.repository.MemberRepository
+import com.dh.baro.identity.domain.repository.UserRepository
 import com.dh.baro.identity.domain.repository.SocialAccountRepository
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
 @Service
-class MemberService(
-    private val memberRepository: MemberRepository,
+class UserService(
+    private val userRepository: UserRepository,
     private val socialAccountRepository: SocialAccountRepository,
 ) {
 
@@ -20,15 +20,13 @@ class MemberService(
         socialUserInfo: OauthApi.SocialUserInfo
     ): RegistrationResult {
         socialAccountRepository.findByProviderAndProviderId(provider, socialUserInfo.providerId)
-            ?.let { existingAccount ->
-                return RegistrationResult(existingAccount.member.id, existingAccount.member.role.name, isNew = false)
-            }
+            ?.run { return RegistrationResult(user.id, user.role, false) }
 
-        val member = Member.newMember(socialUserInfo.nickname, socialUserInfo.email)
-            .let { newMember -> memberRepository.save(newMember) }
-        SocialAccount.of(member, provider, socialUserInfo.providerId)
+        val user = User.newMember(socialUserInfo.nickname, socialUserInfo.email)
+            .let { newMember -> userRepository.save(newMember) }
+        SocialAccount.of(user, provider, socialUserInfo.providerId)
             .let { socialAccount -> socialAccountRepository.save(socialAccount) }
 
-        return RegistrationResult(member.id, member.role.name, isNew = true)
+        return RegistrationResult(user.id, user.role, isNew = true)
     }
 }

--- a/src/main/kotlin/com/dh/baro/identity/domain/service/UserService.kt
+++ b/src/main/kotlin/com/dh/baro/identity/domain/service/UserService.kt
@@ -22,11 +22,15 @@ class UserService(
         socialAccountRepository.findByProviderAndProviderId(provider, socialUserInfo.providerId)
             ?.run { return RegistrationResult(user.id, user.role, false) }
 
-        val user = User.newMember(socialUserInfo.nickname, socialUserInfo.email)
-            .let { newMember -> userRepository.save(newMember) }
+        val user = User.newUser(socialUserInfo.nickname, socialUserInfo.email)
+            .let { newUser -> userRepository.save(newUser) }
         SocialAccount.of(user, provider, socialUserInfo.providerId)
             .let { socialAccount -> socialAccountRepository.save(socialAccount) }
 
-        return RegistrationResult(user.id, user.role, isNew = true)
+        return RegistrationResult(
+            userId = user.id,
+            userRole = user.role,
+            isNew = true,
+        )
     }
 }

--- a/src/main/kotlin/com/dh/baro/identity/presentation/AuthController.kt
+++ b/src/main/kotlin/com/dh/baro/identity/presentation/AuthController.kt
@@ -1,7 +1,7 @@
 package com.dh.baro.identity.presentation
 
-import com.dh.baro.core.auth.SessionKeys.MEMBER_ID
-import com.dh.baro.core.auth.SessionKeys.MEMBER_ROLE
+import com.dh.baro.core.auth.SessionKeys.USER_ID
+import com.dh.baro.core.auth.SessionKeys.USER_ROLE
 import com.dh.baro.identity.application.AuthFacade
 import com.dh.baro.identity.application.dto.LoginResponse
 import com.dh.baro.identity.presentation.dto.OauthLoginRequest
@@ -23,8 +23,8 @@ class AuthController(
     ): LoginResponse {
         val result = authFacade.login(oauthLoginRequest.provider, oauthLoginRequest.accessToken)
         request.session.apply {
-            setAttribute(MEMBER_ID, result.memberId)
-            setAttribute(MEMBER_ROLE, result.memberRole)
+            setAttribute(USER_ID, result.userId)
+            setAttribute(USER_ROLE, result.userRole)
         }
 
         return LoginResponse(result.isNew)

--- a/src/main/kotlin/com/dh/baro/look/domain/Look.kt
+++ b/src/main/kotlin/com/dh/baro/look/domain/Look.kt
@@ -1,7 +1,7 @@
 package com.dh.baro.look.domain
 
 import com.dh.baro.core.AbstractTime
-import com.dh.baro.identity.domain.Member
+import com.dh.baro.identity.domain.User
 import com.dh.baro.product.domain.Product
 import jakarta.persistence.*
 
@@ -14,7 +14,7 @@ class Look(
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "creator_id")
-    val creator: Member? = null,
+    val creator: User? = null,
 
     @Column(name = "title", nullable = false)
     var title: String,

--- a/src/main/kotlin/com/dh/baro/order/domain/Order.kt
+++ b/src/main/kotlin/com/dh/baro/order/domain/Order.kt
@@ -1,7 +1,7 @@
 package com.dh.baro.order.domain
 
 import com.dh.baro.core.AbstractTime
-import com.dh.baro.identity.domain.Member
+import com.dh.baro.identity.domain.User
 import jakarta.persistence.*
 
 @Entity
@@ -12,8 +12,8 @@ class Order(
     val id: Long,
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id", nullable = false)
-    val member: Member,
+    @JoinColumn(name = "user_id", nullable = false)
+    val user: User,
 
     @Column(name = "total_price", nullable = false)
     var totalPrice: Int,

--- a/src/main/kotlin/com/dh/baro/preference/domain/LookLike.kt
+++ b/src/main/kotlin/com/dh/baro/preference/domain/LookLike.kt
@@ -1,7 +1,7 @@
 package com.dh.baro.preference.domain
 
 import com.dh.baro.core.AbstractTime
-import com.dh.baro.identity.domain.Member
+import com.dh.baro.identity.domain.User
 import com.dh.baro.look.domain.Look
 import jakarta.persistence.EmbeddedId
 import jakarta.persistence.Entity
@@ -19,8 +19,8 @@ class LookLike(
 
     @MapsId("memberId")
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id", insertable = false, updatable = false)
-    val member: Member,
+    @JoinColumn(name = "user_id", insertable = false, updatable = false)
+    val user: User,
 
     @MapsId("lookId")
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/kotlin/com/dh/baro/preference/domain/LookLike.kt
+++ b/src/main/kotlin/com/dh/baro/preference/domain/LookLike.kt
@@ -17,7 +17,7 @@ class LookLike(
     @EmbeddedId
     val id: LookReactionId,
 
-    @MapsId("memberId")
+    @MapsId("userId")
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", insertable = false, updatable = false)
     val user: User,

--- a/src/main/kotlin/com/dh/baro/preference/domain/LookReactionId.kt
+++ b/src/main/kotlin/com/dh/baro/preference/domain/LookReactionId.kt
@@ -6,8 +6,8 @@ import java.io.Serializable
 
 @Embeddable
 data class LookReactionId(
-    @Column(name = "member_id")
-    val memberId: Long,
+    @Column(name = "user_id")
+    val userId: Long,
 
     @Column(name = "look_id")
     val lookId: Long

--- a/src/main/kotlin/com/dh/baro/preference/domain/ProductLike.kt
+++ b/src/main/kotlin/com/dh/baro/preference/domain/ProductLike.kt
@@ -1,7 +1,7 @@
 package com.dh.baro.preference.domain
 
 import com.dh.baro.core.AbstractTime
-import com.dh.baro.identity.domain.Member
+import com.dh.baro.identity.domain.User
 import com.dh.baro.product.domain.Product
 import jakarta.persistence.EmbeddedId
 import jakarta.persistence.Entity
@@ -17,10 +17,10 @@ class ProductLike(
     @EmbeddedId
     val id: ProductLikeId,
 
-    @MapsId("memberId")
+    @MapsId("userId")
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id", insertable = false, updatable = false)
-    val member: Member,
+    @JoinColumn(name = "user_id", insertable = false, updatable = false)
+    val user: User,
 
     @MapsId("productId")
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/kotlin/com/dh/baro/preference/domain/ProductLikeId.kt
+++ b/src/main/kotlin/com/dh/baro/preference/domain/ProductLikeId.kt
@@ -6,8 +6,8 @@ import java.io.Serializable
 
 @Embeddable
 data class ProductLikeId(
-    @Column(name = "member_id")
-    val memberId: Long,
+    @Column(name = "user_id")
+    val userId: Long,
 
     @Column(name = "product_id")
     val productId: Long

--- a/src/main/kotlin/com/dh/baro/product/domain/Product.kt
+++ b/src/main/kotlin/com/dh/baro/product/domain/Product.kt
@@ -14,7 +14,7 @@ class Product(
     @Column(name = "product_name", nullable = false)
     var name: String,
 
-    @Column(name = "price", nullable = false)
+    @Column(name = "price", nullable = false, precision = 10, scale = 0)
     var price: BigDecimal,
 
     @Column(name = "quantity", nullable = false)

--- a/src/main/kotlin/com/dh/baro/product/domain/Product.kt
+++ b/src/main/kotlin/com/dh/baro/product/domain/Product.kt
@@ -2,6 +2,7 @@ package com.dh.baro.product.domain
 
 import com.dh.baro.core.AbstractTime
 import jakarta.persistence.*
+import java.math.BigDecimal
 
 @Entity
 @Table(name = "products")
@@ -14,7 +15,7 @@ class Product(
     var name: String,
 
     @Column(name = "price", nullable = false)
-    var price: Int,
+    var price: BigDecimal,
 
     @Column(name = "quantity", nullable = false)
     var quantity: Int = 0,
@@ -26,7 +27,12 @@ class Product(
     @Column(name = "likes_count", nullable = false)
     var likesCount: Int = 0,
 
-    @OneToMany(mappedBy = "product", cascade = [CascadeType.ALL], orphanRemoval = true)
+    @OneToMany(
+        mappedBy = "product",
+        fetch = FetchType.LAZY,
+        cascade = [CascadeType.ALL],
+        orphanRemoval = true,
+    )
     val images: MutableList<ProductImage> = mutableListOf(),
 
     @ManyToMany
@@ -37,4 +43,8 @@ class Product(
     )
     val categories: MutableSet<Category> = mutableSetOf()
 
-) : AbstractTime()
+) : AbstractTime() {
+
+    fun getThumbnailUrl(): String? =
+        images.firstOrNull { it.isThumbnail }?.imageUrl
+}

--- a/src/main/kotlin/com/dh/baro/product/domain/ProductRepository.kt
+++ b/src/main/kotlin/com/dh/baro/product/domain/ProductRepository.kt
@@ -1,0 +1,5 @@
+package com.dh.baro.product.domain
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface ProductRepository : JpaRepository<Product, Long>


### PR DESCRIPTION
## Issue Number
#7 

## As-Is
<!-- Describe the current issue or problem -->
* 장바구니 관련 도메인, 요청/응답 DTO, 서비스 계층, API가 존재하지 않음
* 상품 추가, 수량 변경, 삭제 및 전체 조회에 대한 구조가 미비함
* 장바구니 항목 수 제한, 응답 구조 설계, 유효성 검증이 누락됨

## To-Be
<!-- Describe the intended changes or improvements -->
* [x] `CartItem`, `CartService`, `CartFacade`, `CartController` 등 장바구니 도메인 및 API 전반 구현
* [x] 장바구니 요청/응답 DTO (`AddItemRequest`, `UpdateQuantityRequest`, `CartItemResponse`, `CartResponse`) 정의
* [x] 최대 20개까지 장바구니 항목 제한 정책(`CartPolicy`) 적용
* [x] 사용자 및 상품 유효성 검증 및 예외 메시지 정의 (`ErrorMessage`)
* [x] 장바구니 수량 증가, 변경, 삭제 기능 포함
* [x] `@EntityGraph` 활용으로 N+1 문제 방지
* [x] 유효성 검증 어노테이션 적용으로 입력 데이터 제한 (`@Min`, `@Positive`)
* [x] 전체 응답에서 총합 가격 계산 로직 포함 (`CartResponse.from()`)

## ✅ Check List

- [x] Have all tests passed?
- [x] Have all commits been pushed?
- [x] Did you verify the target branch for the merge?
- [x] Did you assign the appropriate assignee(s)?
- [x] Did you set the correct label(s)?

## 📸 Test Screenshot

## Additional Description
