### PR TITLE
[FEAT] 상품 목록(인기,신상)/상세/생성 기능 및 커서 기반 페이징 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,6 +9,12 @@ plugins {
 group = "${group}"
 version = "${version}"
 
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(jvmTarget)
+    }
+}
+
 repositories {
     mavenCentral()
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,7 @@ springbootVersion=3.4.3
 springMockkVersion=4.0.0
 
 ### Swagger ###
-springdocVersion=2.6.0
+springdocVersion=2.8.0
 
 ### Jetbrain ###
 jetbrainKotlinVersion=1.9.22

--- a/src/main/kotlin/com/dh/baro/cart/presentation/dto/CartItemResponse.kt
+++ b/src/main/kotlin/com/dh/baro/cart/presentation/dto/CartItemResponse.kt
@@ -6,7 +6,7 @@ data class CartItemResponse(
     val itemId: Long,
     val productId: Long,
     val productName: String,
-    val productImageUrl: String?,
+    val productThumbnailUrl: String?,
     val price: BigDecimal,
     val quantity: Int,
     val subtotal: BigDecimal,

--- a/src/main/kotlin/com/dh/baro/cart/presentation/dto/CartResponse.kt
+++ b/src/main/kotlin/com/dh/baro/cart/presentation/dto/CartResponse.kt
@@ -22,7 +22,7 @@ data class CartResponse(
             itemId = id,
             productId = product.id,
             productName = product.name,
-            productImageUrl = product.getThumbnailUrl(),
+            productThumbnailUrl = product.thumbnailUrl,
             price = product.price,
             quantity = quantity,
             subtotal = product.price

--- a/src/main/kotlin/com/dh/baro/core/Cursor.kt
+++ b/src/main/kotlin/com/dh/baro/core/Cursor.kt
@@ -1,0 +1,5 @@
+package com.dh.baro.core
+
+class Cursor (
+    val id: Long,
+)

--- a/src/main/kotlin/com/dh/baro/core/ErrorMessage.kt
+++ b/src/main/kotlin/com/dh/baro/core/ErrorMessage.kt
@@ -16,6 +16,10 @@ enum class ErrorMessage(val message: String) {
     // Product
     PRODUCT_NOT_FOUND("상품을 찾을 수 없습니다: %d"),
 
+    // Category
+    CATEGORY_ALREADY_EXISTS("카테고리(id = %d)는 이미 존재합니다."),
+    CATEGORY_NOT_FOUND("카테고리를 찾을 수 없습니다: %d"),
+
     //Cart
     CART_ITEM_NOT_FOUND("장바구니 항목을 찾을 수 없습니다: %d"),
     CART_ITEM_LIMIT_EXCEEDED("장바구니에는 최대 20개의 상품만 담을 수 있습니다."),

--- a/src/main/kotlin/com/dh/baro/core/ErrorMessage.kt
+++ b/src/main/kotlin/com/dh/baro/core/ErrorMessage.kt
@@ -15,10 +15,11 @@ enum class ErrorMessage(val message: String) {
 
     // Product
     PRODUCT_NOT_FOUND("상품을 찾을 수 없습니다: %d"),
+    INVALID_POPULAR_PRODUCT_CURSOR("cursorLikes와 cursorId는 함께 지정하거나 함께 생략해야 합니다."),
 
     // Category
     CATEGORY_ALREADY_EXISTS("카테고리(id = %d)는 이미 존재합니다."),
-    CATEGORY_NOT_FOUND("카테고리를 찾을 수 없습니다: %d"),
+    CATEGORY_NOT_FOUND("카테고리를 찾을 수 없습니다: %s"),
 
     //Cart
     CART_ITEM_NOT_FOUND("장바구니 항목을 찾을 수 없습니다: %d"),

--- a/src/main/kotlin/com/dh/baro/core/SliceResponse.kt
+++ b/src/main/kotlin/com/dh/baro/core/SliceResponse.kt
@@ -1,0 +1,23 @@
+package com.dh.baro.core
+
+import org.springframework.data.domain.Slice
+
+data class SliceResponse<T>(
+    val content: List<T>,
+    val hasNext: Boolean,
+    val nextCursor: Any?,
+) {
+
+    companion object {
+        fun <T, R> from(
+            slice: Slice<T>,
+            mapper: (T) -> R,
+            cursorExtractor: (T) -> Any,
+        ): SliceResponse<R> =
+            SliceResponse(
+                content = slice.content.map(mapper),
+                hasNext = slice.hasNext(),
+                nextCursor = slice.content.lastOrNull()?.let(cursorExtractor),
+            )
+    }
+}

--- a/src/main/kotlin/com/dh/baro/identity/presentation/AuthController.kt
+++ b/src/main/kotlin/com/dh/baro/identity/presentation/AuthController.kt
@@ -15,8 +15,8 @@ class AuthController(
     private val authFacade: AuthFacade
 ) {
 
-    @ResponseStatus(HttpStatus.OK)
     @PostMapping("/login/oauth")
+    @ResponseStatus(HttpStatus.OK)
     fun loginWithOauth(
         @RequestBody oauthLoginRequest: OauthLoginRequest,
         request: HttpServletRequest
@@ -30,8 +30,8 @@ class AuthController(
         return LoginResponse(result.isNew)
     }
 
-    @ResponseStatus(HttpStatus.NO_CONTENT)
     @PostMapping("/logout")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
     fun logout(request: HttpServletRequest) {
         request.session.invalidate()
     }

--- a/src/main/kotlin/com/dh/baro/product/application/CategoryFacade.kt
+++ b/src/main/kotlin/com/dh/baro/product/application/CategoryFacade.kt
@@ -1,0 +1,15 @@
+package com.dh.baro.product.application
+
+import com.dh.baro.product.domain.Category
+import com.dh.baro.product.domain.CategoryService
+import com.dh.baro.product.presentation.dto.CategoryCreateRequest
+import org.springframework.stereotype.Service
+
+@Service
+class CategoryFacade(
+    private val categoryService: CategoryService,
+) {
+
+    fun createCategory(request: CategoryCreateRequest): Category =
+        categoryService.createCategory(request.id, request.name)
+}

--- a/src/main/kotlin/com/dh/baro/product/application/ProductCreateCommand.kt
+++ b/src/main/kotlin/com/dh/baro/product/application/ProductCreateCommand.kt
@@ -1,0 +1,26 @@
+package com.dh.baro.product.application
+
+import com.dh.baro.product.presentation.dto.ProductCreateRequest
+import java.math.BigDecimal
+
+data class ProductCreateCommand(
+    val name: String,
+    val price: BigDecimal,
+    val quantity: Int,
+    val description: String?,
+    val likesCount: Int,
+    val thumbnailUrl: String,
+) {
+
+    companion object {
+        fun toCommand(request: ProductCreateRequest): ProductCreateCommand =
+            ProductCreateCommand(
+                name = request.name,
+                price = request.price,
+                quantity = request.quantity,
+                description = request.description,
+                likesCount = request.likesCount,
+                thumbnailUrl = request.thumbnailUrl,
+            )
+    }
+}

--- a/src/main/kotlin/com/dh/baro/product/application/ProductFacade.kt
+++ b/src/main/kotlin/com/dh/baro/product/application/ProductFacade.kt
@@ -1,0 +1,20 @@
+package com.dh.baro.product.application
+
+import com.dh.baro.product.domain.CategoryService
+import com.dh.baro.product.domain.Product
+import com.dh.baro.product.domain.ProductService
+import com.dh.baro.product.presentation.dto.ProductCreateRequest
+import org.springframework.stereotype.Service
+
+@Service
+class ProductFacade(
+    private val productService: ProductService,
+    private val categoryService: CategoryService,
+) {
+
+    fun createProduct(request: ProductCreateRequest): Product {
+        val categories = categoryService.checkCategoryIdsExist(request.categoryIds)
+        val cmd = ProductCreateCommand.toCommand(request)
+        return productService.createProduct(cmd, categories)
+    }
+}

--- a/src/main/kotlin/com/dh/baro/product/application/ProductFacade.kt
+++ b/src/main/kotlin/com/dh/baro/product/application/ProductFacade.kt
@@ -13,7 +13,7 @@ class ProductFacade(
 ) {
 
     fun createProduct(request: ProductCreateRequest): Product {
-        val categories = categoryService.checkCategoryIdsExist(request.categoryIds)
+        val categories = categoryService.getCategoriesByIds(request.categoryIds)
         val cmd = ProductCreateCommand.toCommand(request)
         return productService.createProduct(cmd, categories)
     }

--- a/src/main/kotlin/com/dh/baro/product/domain/CategoryRepository.kt
+++ b/src/main/kotlin/com/dh/baro/product/domain/CategoryRepository.kt
@@ -1,0 +1,5 @@
+package com.dh.baro.product.domain
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface CategoryRepository : JpaRepository<Category, Long>

--- a/src/main/kotlin/com/dh/baro/product/domain/CategoryService.kt
+++ b/src/main/kotlin/com/dh/baro/product/domain/CategoryService.kt
@@ -18,7 +18,7 @@ class CategoryService(
         return categoryRepository.save(Category(id, name))
     }
 
-    fun checkCategoryIdsExist(ids: List<Long>): List<Category> {
+    fun getCategoriesByIds(ids: List<Long>): List<Category> {
         val categories = categoryRepository.findAllById(ids).toList()
         if (categories.size != ids.size)
             throw IllegalArgumentException(ErrorMessage.CATEGORY_NOT_FOUND.format(ids))

--- a/src/main/kotlin/com/dh/baro/product/domain/CategoryService.kt
+++ b/src/main/kotlin/com/dh/baro/product/domain/CategoryService.kt
@@ -1,0 +1,27 @@
+package com.dh.baro.product.domain
+
+import com.dh.baro.core.ErrorMessage
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+@Transactional(readOnly = true)
+class CategoryService(
+    private val categoryRepository: CategoryRepository,
+) {
+
+    @Transactional
+    fun createCategory(id: Long, name: String): Category {
+        if (categoryRepository.existsById(id))
+            throw IllegalArgumentException(ErrorMessage.CATEGORY_ALREADY_EXISTS.format(id))
+
+        return categoryRepository.save(Category(id, name))
+    }
+
+    fun checkCategoryIdsExist(ids: List<Long>): List<Category> {
+        val categories = categoryRepository.findAllById(ids).toList()
+        if (categories.size != ids.size)
+            throw IllegalArgumentException(ErrorMessage.CATEGORY_NOT_FOUND.format(ids))
+        return categories
+    }
+}

--- a/src/main/kotlin/com/dh/baro/product/domain/Product.kt
+++ b/src/main/kotlin/com/dh/baro/product/domain/Product.kt
@@ -27,6 +27,9 @@ class Product(
     @Column(name = "likes_count", nullable = false)
     var likesCount: Int = 0,
 
+    @Column(name = "thumbnail_url", nullable = false, length = 300)
+    var thumbnailUrl: String,
+
     @OneToMany(
         mappedBy = "product",
         fetch = FetchType.LAZY,
@@ -35,16 +38,12 @@ class Product(
     )
     val images: MutableList<ProductImage> = mutableListOf(),
 
-    @ManyToMany
-    @JoinTable(
-        name = "product_categories",
-        joinColumns = [JoinColumn(name = "product_id")],
-        inverseJoinColumns = [JoinColumn(name = "category_id")]
+    @OneToMany(
+        mappedBy = "product",
+        cascade = [CascadeType.ALL],
+        orphanRemoval = true,
+        fetch = FetchType.LAZY
     )
-    val categories: MutableSet<Category> = mutableSetOf()
+    val productCategories: MutableList<ProductCategory> = mutableListOf()
 
-) : AbstractTime() {
-
-    fun getThumbnailUrl(): String? =
-        images.firstOrNull { it.isThumbnail }?.imageUrl
-}
+) : AbstractTime()

--- a/src/main/kotlin/com/dh/baro/product/domain/Product.kt
+++ b/src/main/kotlin/com/dh/baro/product/domain/Product.kt
@@ -12,7 +12,7 @@ class Product(
     @Column(name = "id")
     val id: Long,
 
-    @Column(name = "product_name", nullable = false)
+    @Column(name = "product_name", nullable = false, length = 100)
     var name: String,
 
     @Column(name = "price", nullable = false, precision = 10, scale = 0)

--- a/src/main/kotlin/com/dh/baro/product/domain/Product.kt
+++ b/src/main/kotlin/com/dh/baro/product/domain/Product.kt
@@ -1,6 +1,7 @@
 package com.dh.baro.product.domain
 
 import com.dh.baro.core.AbstractTime
+import com.dh.baro.core.IdGenerator
 import jakarta.persistence.*
 import java.math.BigDecimal
 
@@ -8,7 +9,7 @@ import java.math.BigDecimal
 @Table(name = "products")
 class Product(
     @Id
-    @Column(name = "product_id")
+    @Column(name = "id")
     val id: Long,
 
     @Column(name = "product_name", nullable = false)
@@ -44,6 +45,34 @@ class Product(
         orphanRemoval = true,
         fetch = FetchType.LAZY
     )
-    val productCategories: MutableList<ProductCategory> = mutableListOf()
+    val productCategories: MutableList<ProductCategory> = mutableListOf(),
 
-) : AbstractTime()
+) : AbstractTime() {
+
+    fun addCategory(category: Category) {
+        if (productCategories.any { it.category == category }) return
+
+        val pc = ProductCategory.of(this, category)
+        productCategories.add(pc)
+    }
+
+    companion object {
+        fun newProduct(
+            name: String,
+            price: BigDecimal,
+            quantity: Int,
+            thumbnailUrl: String,
+            description: String? = null,
+            likesCount: Int = 0,
+        ): Product =
+            Product(
+                id = IdGenerator.generate(),
+                name = name,
+                price = price,
+                quantity = quantity,
+                description = description,
+                likesCount = likesCount,
+                thumbnailUrl = thumbnailUrl,
+            )
+    }
+}

--- a/src/main/kotlin/com/dh/baro/product/domain/Product.kt
+++ b/src/main/kotlin/com/dh/baro/product/domain/Product.kt
@@ -37,7 +37,7 @@ class Product(
         cascade = [CascadeType.ALL],
         orphanRemoval = true,
     )
-    val images: MutableList<ProductImage> = mutableListOf(),
+    val images: MutableSet<ProductImage> = mutableSetOf(),
 
     @OneToMany(
         mappedBy = "product",
@@ -45,7 +45,7 @@ class Product(
         orphanRemoval = true,
         fetch = FetchType.LAZY
     )
-    val productCategories: MutableList<ProductCategory> = mutableListOf(),
+    val productCategories: MutableSet<ProductCategory> = mutableSetOf(),
 
 ) : AbstractTime() {
 

--- a/src/main/kotlin/com/dh/baro/product/domain/ProductCategory.kt
+++ b/src/main/kotlin/com/dh/baro/product/domain/ProductCategory.kt
@@ -1,0 +1,19 @@
+package com.dh.baro.product.domain
+
+import jakarta.persistence.*
+
+@Entity
+@Table(name = "product_categories")
+class ProductCategory(
+    @Id
+    @Column(name = "id")
+    val id: Long,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "product_id")
+    val product: Product,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "category_id")
+    val category: Category
+)

--- a/src/main/kotlin/com/dh/baro/product/domain/ProductCategory.kt
+++ b/src/main/kotlin/com/dh/baro/product/domain/ProductCategory.kt
@@ -1,5 +1,6 @@
 package com.dh.baro.product.domain
 
+import com.dh.baro.core.IdGenerator
 import jakarta.persistence.*
 
 @Entity
@@ -15,5 +16,15 @@ class ProductCategory(
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "category_id")
-    val category: Category
-)
+    val category: Category,
+) {
+
+    companion object {
+        fun of(product: Product, category: Category): ProductCategory =
+            ProductCategory(
+                id = IdGenerator.generate(),
+                product = product,
+                category = category,
+            )
+    }
+}

--- a/src/main/kotlin/com/dh/baro/product/domain/ProductImage.kt
+++ b/src/main/kotlin/com/dh/baro/product/domain/ProductImage.kt
@@ -19,7 +19,4 @@ class ProductImage(
 
     @Column(name = "display_order", nullable = false)
     val displayOrder: Int,
-
-    @Column(name = "is_thumbnail", nullable = false)
-    val isThumbnail: Boolean = false
 ) : AbstractTime()

--- a/src/main/kotlin/com/dh/baro/product/domain/ProductQueryService.kt
+++ b/src/main/kotlin/com/dh/baro/product/domain/ProductQueryService.kt
@@ -3,6 +3,7 @@ package com.dh.baro.product.domain
 import com.dh.baro.core.ErrorMessage
 import com.dh.baro.core.instant
 import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Slice
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.Instant
@@ -19,7 +20,7 @@ class ProductQueryService(
         cursorLikes: Int?,
         cursorId: Long?,
         size: Int,
-    ): List<Product> {
+    ): Slice<Product> {
         val pageable = PageRequest.of(0, size)
         return productRepository.findPopularProductsByCursor(
             categoryId = categoryId,
@@ -33,13 +34,15 @@ class ProductQueryService(
         categoryId: Long?,
         cursorId: Long?,
         size: Int
-    ): List<Product> =
-        productRepository.findNewestProductsByCursor(
+    ): Slice<Product> {
+        val pageable = PageRequest.of(0, size)
+        return productRepository.findNewestProductsByCursor(
             cutoff = calculateCutoff(),
             categoryId = categoryId,
             cursorId = cursorId,
-            size = size,
+            pageable = pageable,
         )
+    }
 
     private fun calculateCutoff(): Instant =
         instant().minus(NEW_PERIOD_DAYS, ChronoUnit.DAYS)

--- a/src/main/kotlin/com/dh/baro/product/domain/ProductQueryService.kt
+++ b/src/main/kotlin/com/dh/baro/product/domain/ProductQueryService.kt
@@ -1,6 +1,8 @@
 package com.dh.baro.product.domain
 
+import com.dh.baro.core.ErrorMessage
 import com.dh.baro.core.instant
+import org.springframework.data.domain.PageRequest
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.Instant
@@ -12,22 +14,39 @@ class ProductQueryService(
     private val productRepository: ProductRepository,
 ) {
 
-    fun getPopularProducts(categoryId: Long?, cursorId: Long?, size: Int): List<Product> =
-        productRepository.findPopularProductsByCursor(categoryId, cursorId, size)
+    fun getPopularProducts(
+        categoryId: Long?,
+        cursorLikes: Int?,
+        cursorId: Long?,
+        size: Int,
+    ): List<Product> {
+        val pageable = PageRequest.of(0, size)
+        return productRepository.findPopularProductsByCursor(
+            categoryId = categoryId,
+            cursorLikes = cursorLikes,
+            cursorId = cursorId,
+            pageable = pageable,
+        )
+    }
 
-    fun getNewestProducts(categoryId: Long?, cursorId: Long?, size: Int): List<Product> =
+    fun getNewestProducts(
+        categoryId: Long?,
+        cursorId: Long?,
+        size: Int
+    ): List<Product> =
         productRepository.findNewestProductsByCursor(
-            createdAfter = createdAfter(),
+            cutoff = calculateCutoff(),
             categoryId = categoryId,
             cursorId = cursorId,
             size = size,
         )
 
-    private fun createdAfter(): Instant =
+    private fun calculateCutoff(): Instant =
         instant().minus(NEW_PERIOD_DAYS, ChronoUnit.DAYS)
 
     fun getProductDetail(productId: Long): Product =
-        productRepository.findDetailById(productId)
+        productRepository.findDetailProductById(productId)
+            ?: throw IllegalArgumentException(ErrorMessage.PRODUCT_NOT_FOUND.format(productId))
 
     companion object {
         private const val NEW_PERIOD_DAYS = 30L

--- a/src/main/kotlin/com/dh/baro/product/domain/ProductQueryService.kt
+++ b/src/main/kotlin/com/dh/baro/product/domain/ProductQueryService.kt
@@ -1,0 +1,35 @@
+package com.dh.baro.product.domain
+
+import com.dh.baro.core.instant
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+
+@Service
+@Transactional(readOnly = true)
+class ProductQueryService(
+    private val productRepository: ProductRepository,
+) {
+
+    fun getPopularProducts(categoryId: Long?, cursorId: Long?, size: Int): List<Product> =
+        productRepository.findPopularProductsByCursor(categoryId, cursorId, size)
+
+    fun getNewestProducts(categoryId: Long?, cursorId: Long?, size: Int): List<Product> =
+        productRepository.findNewestProductsByCursor(
+            createdAfter = createdAfter(),
+            categoryId = categoryId,
+            cursorId = cursorId,
+            size = size,
+        )
+
+    private fun createdAfter(): Instant =
+        instant().minus(NEW_PERIOD_DAYS, ChronoUnit.DAYS)
+
+    fun getProductDetail(productId: Long): Product =
+        productRepository.findDetailById(productId)
+
+    companion object {
+        private const val NEW_PERIOD_DAYS = 30L
+    }
+}

--- a/src/main/kotlin/com/dh/baro/product/domain/ProductRepository.kt
+++ b/src/main/kotlin/com/dh/baro/product/domain/ProductRepository.kt
@@ -1,5 +1,48 @@
 package com.dh.baro.product.domain
 
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
+import java.time.Instant
 
-interface ProductRepository : JpaRepository<Product, Long>
+interface ProductRepository : JpaRepository<Product, Long> {
+
+    @Query("""
+        select p from Product p
+        where (:categoryId is null or exists (
+                 select 1 from ProductCategory pc
+                 where pc.product = p and pc.category.id = :categoryId ))
+          and (:cursorId is null or p.id < :cursorId)
+        order by p.likesCount desc, p.id desc
+    """)
+    fun findPopularProductsByCursor(
+        @Param("categoryId") categoryId: Long?,
+        @Param("cursorId") cursorId: Long?,
+        @Param("size") size: Int,
+    ): List<Product>
+
+    @Query("""
+        select p from Product p
+        where p.createdAt >= :cutoff
+          and (:categoryId is null or exists (
+                 select 1 from ProductCategory pc
+                 where pc.product = p and pc.category.id = :categoryId ))
+          and (:cursorId is null or p.id < :cursorId)
+        order by p.id desc
+    """)
+    fun findNewestProductsByCursor(
+        @Param("cutoff") createdAfter: Instant,
+        @Param("categoryId") categoryId: Long?,
+        @Param("cursorId") cursorId: Long?,
+        @Param("size") size: Int,
+    ): List<Product>
+
+    @Query("""
+        select p from Product p
+        left join fetch p.images
+        left join fetch p.productCategories pc
+        left join fetch pc.category
+        where p.id = :id
+    """)
+    fun findDetailById(@Param("id") id: Long): Product
+}

--- a/src/main/kotlin/com/dh/baro/product/domain/ProductRepository.kt
+++ b/src/main/kotlin/com/dh/baro/product/domain/ProductRepository.kt
@@ -1,6 +1,7 @@
 package com.dh.baro.product.domain
 
 import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Slice
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
@@ -23,7 +24,7 @@ interface ProductRepository : JpaRepository<Product, Long> {
         @Param("cursorLikes") cursorLikes: Int?,
         @Param("cursorId") cursorId: Long?,
         pageable: Pageable,
-    ): List<Product>
+    ): Slice<Product>
 
     @Query("""
         select p from Product p
@@ -38,8 +39,8 @@ interface ProductRepository : JpaRepository<Product, Long> {
         @Param("cutoff") cutoff: Instant,
         @Param("categoryId") categoryId: Long?,
         @Param("cursorId") cursorId: Long?,
-        @Param("size") size: Int,
-    ): List<Product>
+        pageable: Pageable,
+    ): Slice<Product>
 
     @Query("""
         select p from Product p

--- a/src/main/kotlin/com/dh/baro/product/domain/ProductService.kt
+++ b/src/main/kotlin/com/dh/baro/product/domain/ProductService.kt
@@ -1,0 +1,29 @@
+package com.dh.baro.product.domain
+
+import com.dh.baro.product.application.ProductCreateCommand
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class ProductService(
+    private val productRepository: ProductRepository,
+) {
+
+    @Transactional
+    fun createProduct(cmd: ProductCreateCommand, categories: List<Category>): Product {
+        val product = Product.newProduct(
+            name = cmd.name,
+            price = cmd.price,
+            quantity = cmd.quantity,
+            description = cmd.description,
+            likesCount = cmd.likesCount,
+            thumbnailUrl = cmd.thumbnailUrl,
+        )
+
+        for (category in categories) {
+            product.addCategory(category)
+        }
+
+        return productRepository.save(product)
+    }
+}

--- a/src/main/kotlin/com/dh/baro/product/presentation/CategoryController.kt
+++ b/src/main/kotlin/com/dh/baro/product/presentation/CategoryController.kt
@@ -1,0 +1,22 @@
+package com.dh.baro.product.presentation
+
+import com.dh.baro.product.application.CategoryFacade
+import com.dh.baro.product.presentation.dto.CategoryCreateRequest
+import com.dh.baro.product.presentation.dto.CategoryResponse
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.*
+
+@RestController
+@RequestMapping("/categories")
+class CategoryController(
+    private val categoryFacade: CategoryFacade,
+) {
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    fun createCategory(@Valid @RequestBody request: CategoryCreateRequest): CategoryResponse {
+        val created = categoryFacade.createCategory(request)
+        return CategoryResponse.from(created)
+    }
+}

--- a/src/main/kotlin/com/dh/baro/product/presentation/CategoryController.kt
+++ b/src/main/kotlin/com/dh/baro/product/presentation/CategoryController.kt
@@ -1,5 +1,7 @@
 package com.dh.baro.product.presentation
 
+import com.dh.baro.core.auth.RequireAuth
+import com.dh.baro.identity.domain.UserRole
 import com.dh.baro.product.application.CategoryFacade
 import com.dh.baro.product.presentation.dto.CategoryCreateRequest
 import com.dh.baro.product.presentation.dto.CategoryResponse
@@ -15,6 +17,7 @@ class CategoryController(
 
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
+    @RequireAuth(UserRole.ADMIN)
     fun createCategory(@Valid @RequestBody request: CategoryCreateRequest): CategoryResponse {
         val created = categoryFacade.createCategory(request)
         return CategoryResponse.from(created)

--- a/src/main/kotlin/com/dh/baro/product/presentation/ProductController.kt
+++ b/src/main/kotlin/com/dh/baro/product/presentation/ProductController.kt
@@ -1,14 +1,26 @@
 package com.dh.baro.product.presentation
 
+import com.dh.baro.product.application.ProductFacade
 import com.dh.baro.product.domain.ProductQueryService
+import com.dh.baro.product.presentation.dto.ProductCreateRequest
+import com.dh.baro.product.presentation.dto.ProductDetail
+import com.dh.baro.product.presentation.dto.ProductListItem
+import com.dh.baro.product.presentation.dto.ProductResponse
+import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.*
 
 @RestController
 @RequestMapping("/products")
 class ProductController(
-    private val productQueryService: ProductQueryService
+    private val productFacade: ProductFacade,
+    private val productQueryService: ProductQueryService,
 ) {
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    fun createProduct(@Valid @RequestBody request: ProductCreateRequest): ProductResponse =
+        ProductResponse.from(productFacade.createProduct(request))
 
     @GetMapping("/popular")
     @ResponseStatus(HttpStatus.OK)

--- a/src/main/kotlin/com/dh/baro/product/presentation/ProductController.kt
+++ b/src/main/kotlin/com/dh/baro/product/presentation/ProductController.kt
@@ -1,0 +1,40 @@
+package com.dh.baro.product.presentation
+
+import com.dh.baro.product.domain.ProductQueryService
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.*
+
+@RestController
+@RequestMapping("/products")
+class ProductController(
+    private val productQueryService: ProductQueryService
+) {
+
+    @GetMapping("/popular")
+    @ResponseStatus(HttpStatus.OK)
+    fun getPopularProducts(
+        @RequestParam(required = false) categoryId: Long?,
+        @RequestParam(required = false) cursorId: Long?,
+        @RequestParam(defaultValue = DEFAULT_PAGE_SIZE) size: Int,
+    ): List<ProductListItem> =
+        productQueryService.getPopularProducts(categoryId, cursorId, size)
+            .map(ProductListItem::from)
+
+    @GetMapping("/newest")
+    @ResponseStatus(HttpStatus.OK)
+    fun getNewestProducts(
+        @RequestParam(required = false) categoryId: Long?,
+        @RequestParam(required = false) cursorId: Long?,
+        @RequestParam(defaultValue = DEFAULT_PAGE_SIZE) size: Int,
+    ): List<ProductListItem> =
+        productQueryService.getNewestProducts(categoryId, cursorId, size)
+            .map(ProductListItem::from)
+
+    @GetMapping("/{productId}")
+    fun getProductDetail(@PathVariable productId: Long): ProductDetail =
+        ProductDetail.from(productQueryService.getProductDetail(productId))
+
+    companion object {
+        private const val DEFAULT_PAGE_SIZE = "21"
+    }
+}

--- a/src/main/kotlin/com/dh/baro/product/presentation/ProductController.kt
+++ b/src/main/kotlin/com/dh/baro/product/presentation/ProductController.kt
@@ -1,5 +1,6 @@
 package com.dh.baro.product.presentation
 
+import com.dh.baro.core.ErrorMessage
 import com.dh.baro.product.application.ProductFacade
 import com.dh.baro.product.domain.ProductQueryService
 import com.dh.baro.product.presentation.dto.ProductCreateRequest
@@ -26,11 +27,16 @@ class ProductController(
     @ResponseStatus(HttpStatus.OK)
     fun getPopularProducts(
         @RequestParam(required = false) categoryId: Long?,
+        @RequestParam(required = false) cursorLikes: Int?,
         @RequestParam(required = false) cursorId: Long?,
         @RequestParam(defaultValue = DEFAULT_PAGE_SIZE) size: Int,
-    ): List<ProductListItem> =
-        productQueryService.getPopularProducts(categoryId, cursorId, size)
+    ): List<ProductListItem> {
+        if ((cursorLikes == null) xor (cursorId == null))
+            throw IllegalArgumentException(ErrorMessage.INVALID_POPULAR_PRODUCT_CURSOR.message)
+
+        return productQueryService.getPopularProducts(categoryId, cursorLikes, cursorId, size)
             .map(ProductListItem::from)
+    }
 
     @GetMapping("/newest")
     @ResponseStatus(HttpStatus.OK)

--- a/src/main/kotlin/com/dh/baro/product/presentation/ProductController.kt
+++ b/src/main/kotlin/com/dh/baro/product/presentation/ProductController.kt
@@ -3,6 +3,8 @@ package com.dh.baro.product.presentation
 import com.dh.baro.core.Cursor
 import com.dh.baro.core.ErrorMessage
 import com.dh.baro.core.SliceResponse
+import com.dh.baro.core.auth.RequireAuth
+import com.dh.baro.identity.domain.UserRole
 import com.dh.baro.product.application.ProductFacade
 import com.dh.baro.product.domain.ProductQueryService
 import com.dh.baro.product.presentation.dto.*
@@ -19,6 +21,7 @@ class ProductController(
 
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
+    @RequireAuth(UserRole.STORE_OWNER)
     fun createProduct(@Valid @RequestBody request: ProductCreateRequest): ProductResponse =
         ProductResponse.from(productFacade.createProduct(request))
 

--- a/src/main/kotlin/com/dh/baro/product/presentation/ProductDetail.kt
+++ b/src/main/kotlin/com/dh/baro/product/presentation/ProductDetail.kt
@@ -1,0 +1,25 @@
+package com.dh.baro.product.presentation
+
+import com.dh.baro.product.domain.Product
+import java.math.BigDecimal
+
+data class ProductDetail(
+    val id: Long,
+    val name: String,
+    val price: BigDecimal,
+    val description: String?,
+    val images: List<String>,
+    val categories: List<String>,
+) {
+
+    companion object {
+        fun from(product: Product) = ProductDetail(
+            id = product.id,
+            name = product.name,
+            price = product.price,
+            description = product.description,
+            images = product.images.sortedBy { it.displayOrder }.map { it.imageUrl },
+            categories = product.productCategories.map { it.category.name },
+        )
+    }
+}

--- a/src/main/kotlin/com/dh/baro/product/presentation/ProductListItem.kt
+++ b/src/main/kotlin/com/dh/baro/product/presentation/ProductListItem.kt
@@ -1,0 +1,21 @@
+package com.dh.baro.product.presentation
+
+import com.dh.baro.product.domain.Product
+import java.math.BigDecimal
+
+data class ProductListItem(
+    val id: Long,
+    val name: String,
+    val price: BigDecimal,
+    val thumbnailUrl: String?,
+) {
+
+    companion object {
+        fun from(product: Product) = ProductListItem(
+            id = product.id,
+            name = product.name,
+            price = product.price,
+            thumbnailUrl = product.thumbnailUrl,
+        )
+    }
+}

--- a/src/main/kotlin/com/dh/baro/product/presentation/dto/CategoryCreateRequest.kt
+++ b/src/main/kotlin/com/dh/baro/product/presentation/dto/CategoryCreateRequest.kt
@@ -1,0 +1,12 @@
+package com.dh.baro.product.presentation.dto
+
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Size
+
+data class CategoryCreateRequest(
+    @field:NotBlank
+    val id: Long,
+
+    @field:Size(min = 1, max = 50)
+    val name: String,
+)

--- a/src/main/kotlin/com/dh/baro/product/presentation/dto/CategoryResponse.kt
+++ b/src/main/kotlin/com/dh/baro/product/presentation/dto/CategoryResponse.kt
@@ -1,0 +1,16 @@
+package com.dh.baro.product.presentation.dto
+
+import com.dh.baro.product.domain.Category
+
+data class CategoryResponse(
+    val id: Long,
+    val name: String,
+) {
+
+    companion object {
+        fun from(entity: Category) = CategoryResponse(
+            id = entity.id,
+            name = entity.name,
+        )
+    }
+}

--- a/src/main/kotlin/com/dh/baro/product/presentation/dto/PopularCursor.kt
+++ b/src/main/kotlin/com/dh/baro/product/presentation/dto/PopularCursor.kt
@@ -1,0 +1,6 @@
+package com.dh.baro.product.presentation.dto
+
+data class PopularCursor(
+    val id: Long,
+    val likes: Int,
+)

--- a/src/main/kotlin/com/dh/baro/product/presentation/dto/ProductCreateRequest.kt
+++ b/src/main/kotlin/com/dh/baro/product/presentation/dto/ProductCreateRequest.kt
@@ -1,0 +1,26 @@
+package com.dh.baro.product.presentation.dto
+
+import jakarta.validation.constraints.*
+import java.math.BigDecimal
+
+data class ProductCreateRequest(
+    @field:Size(min = 1, max = 100)
+    val name: String,
+
+    @field:Positive
+    val price: BigDecimal,
+
+    @field:PositiveOrZero
+    val quantity: Int,
+
+    val description: String? = null,
+
+    @field:PositiveOrZero
+    val likesCount: Int,
+
+    @field:NotBlank
+    val thumbnailUrl: String,
+
+    @field:NotEmpty
+    val categoryIds: List<Long>,
+)

--- a/src/main/kotlin/com/dh/baro/product/presentation/dto/ProductDetail.kt
+++ b/src/main/kotlin/com/dh/baro/product/presentation/dto/ProductDetail.kt
@@ -1,4 +1,4 @@
-package com.dh.baro.product.presentation
+package com.dh.baro.product.presentation.dto
 
 import com.dh.baro.product.domain.Product
 import java.math.BigDecimal

--- a/src/main/kotlin/com/dh/baro/product/presentation/dto/ProductListItem.kt
+++ b/src/main/kotlin/com/dh/baro/product/presentation/dto/ProductListItem.kt
@@ -1,4 +1,4 @@
-package com.dh.baro.product.presentation
+package com.dh.baro.product.presentation.dto
 
 import com.dh.baro.product.domain.Product
 import java.math.BigDecimal

--- a/src/main/kotlin/com/dh/baro/product/presentation/dto/ProductResponse.kt
+++ b/src/main/kotlin/com/dh/baro/product/presentation/dto/ProductResponse.kt
@@ -1,0 +1,25 @@
+package com.dh.baro.product.presentation.dto
+
+import com.dh.baro.product.domain.Product
+import java.math.BigDecimal
+
+data class ProductResponse(
+    val id: Long,
+    val name: String,
+    val price: BigDecimal,
+    val quantity: Int,
+    val thumbnailUrl: String,
+    val categoryIds: List<Long>,
+) {
+
+    companion object {
+        fun from(product: Product) = ProductResponse(
+            id = product.id,
+            name = product.name,
+            price = product.price,
+            quantity = product.quantity,
+            thumbnailUrl = product.thumbnailUrl,
+            categoryIds = product.productCategories.map { it.category.id },
+        )
+    }
+}

--- a/src/test/kotlin/com/dh/baro/product/domain/CategoryServiceTest.kt
+++ b/src/test/kotlin/com/dh/baro/product/domain/CategoryServiceTest.kt
@@ -1,0 +1,70 @@
+package com.dh.baro.product.domain
+
+import com.dh.baro.core.ErrorMessage
+import io.kotest.assertions.throwables.shouldNotThrowAny
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.DisplayName
+import org.springframework.boot.autoconfigure.domain.EntityScan
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories
+import org.springframework.test.context.ContextConfiguration
+import org.springframework.test.context.TestPropertySource
+
+@DataJpaTest
+@ContextConfiguration(classes = [CategoryService::class])
+@TestPropertySource("classpath:test.properties")
+@EntityScan("com.dh.baro.product.domain")
+@EnableJpaRepositories("com.dh.baro.product.domain")
+@DisplayName("CategoryService 클래스의")
+internal class CategoryServiceTest(
+    private val categoryService: CategoryService,
+    private val categoryRepository: CategoryRepository,
+) : DescribeSpec({
+
+    afterEach { categoryRepository.deleteAll() }
+
+    describe("createCategory 메서드는") {
+
+        it("새 ID이면 저장 후 반환한다") {
+            val saved = shouldNotThrowAny { categoryService.createCategory(10L, "TOP") }
+            saved.id shouldBe 10L
+            categoryRepository.existsById(10L) shouldBe true
+        }
+
+        context("이미 존재하는 ID이면") {
+            val existingCategoryId = 1L
+            it("IllegalArgumentException를 발생시킨다") {
+                categoryRepository.save(Category(existingCategoryId, "TOP"))
+                shouldThrow<IllegalArgumentException> {
+                    categoryService.createCategory(1L, "NEW_NAME")
+                }.message shouldBe ErrorMessage.CATEGORY_ALREADY_EXISTS.format(existingCategoryId)
+            }
+        }
+    }
+
+    describe("checkCategoryIdsExist 메서드는") {
+
+        lateinit var ids: List<Long>
+
+        beforeEach {
+            categoryRepository.saveAll(
+                listOf(Category(1L, "A"), Category(2L, "B"), Category(3L, "C"))
+            )
+            ids = listOf(1L, 2L, 3L)
+        }
+
+        it("모든 ID가 존재하면 Category 리스트를 반환") {
+            val result = shouldNotThrowAny { categoryService.getCategoriesByIds(ids) }
+            result.map { it.id }.shouldContainExactly(ids)
+        }
+
+        it("일부 ID가 없으면 IllegalArgumentException") {
+            shouldThrow<IllegalArgumentException> {
+                categoryService.getCategoriesByIds(listOf(1L, 99L))
+            }.message shouldBe ErrorMessage.CATEGORY_NOT_FOUND.format(listOf(1L, 99L))
+        }
+    }
+})

--- a/src/test/kotlin/com/dh/baro/product/domain/Fixture.kt
+++ b/src/test/kotlin/com/dh/baro/product/domain/Fixture.kt
@@ -1,0 +1,49 @@
+package com.dh.baro.product.domain
+
+import java.math.BigDecimal
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+import kotlin.random.Random
+
+fun categoryFixture(id: Long, name: String = "CAT_$id") =
+    Category(id = id, name = name)
+
+fun productFixture(
+    id: Long,
+    name: String,
+    category: Category,
+    likes: Int = Random.nextInt(0, 500),
+    createdAtAgoDays: Long = 0L // 0=지금, 31=한달 전
+): Product {
+    val product = Product(
+        id = id,
+        name = name,
+        price = BigDecimal("19900"),
+        quantity = 10,
+        thumbnailUrl = "https://example.com/$id-thumb.jpg",
+        likesCount = likes,
+    )
+
+    product.images += ProductImage(
+        id = id * 100,
+        product = product,
+        imageUrl = "https://example.com/$id-1.jpg",
+        displayOrder = 1,
+    )
+
+    product.productCategories += ProductCategory(
+        id = id * 10,
+        product = product,
+        category = category,
+    )
+
+    if (createdAtAgoDays > 0) {
+        val field = product.javaClass.superclass!!.getDeclaredField("createdAt")
+        field.isAccessible = true
+        field.set(
+            product,
+            Instant.now().minus(createdAtAgoDays, ChronoUnit.DAYS)
+        )
+    }
+    return product
+}

--- a/src/test/kotlin/com/dh/baro/product/domain/ProductQueryServiceTest.kt
+++ b/src/test/kotlin/com/dh/baro/product/domain/ProductQueryServiceTest.kt
@@ -1,5 +1,6 @@
 package com.dh.baro.product.domain
 
+import com.dh.baro.core.ErrorMessage
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.assertions.throwables.shouldNotThrowAny
 import io.kotest.core.spec.style.DescribeSpec
@@ -7,7 +8,6 @@ import io.kotest.matchers.collections.shouldBeSortedWith
 import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.shouldBe
-import jakarta.persistence.EntityNotFoundException
 import org.junit.jupiter.api.DisplayName
 import org.springframework.boot.autoconfigure.domain.EntityScan
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
@@ -45,51 +45,101 @@ internal class ProductQueryServiceTest(
     afterEach { productRepository.deleteAll() }
 
     describe("getPopularProducts 메서드는") {
+        context("size 만큼만 요청하면") {
+            val requestedSize = 1
 
-        it("size 파라미터 만큼만 반환한다") {
-            val list = productQueryService.getPopularProducts(null, null, size = 1)
-            list.size shouldBe 1
-            list.first() shouldBe p1
+            it("가장 인기 상품부터 size 개수만 반환한다") {
+                val expectedId = p3.id
+                val result = productQueryService.getPopularProducts(
+                    categoryId = null,
+                    cursorLikes = null,
+                    cursorId = null,
+                    size = requestedSize,
+                )
+                result.size shouldBe requestedSize
+                result.first().id shouldBe expectedId
+            }
         }
 
-        it("cursorId 이후 데이터만 반환한다") {
-            val list = productQueryService.getPopularProducts(null, cursorId = p1.id, size = 10)
-            list.shouldContainExactly(p2, p3)
+        context("cursor(likes,id)를 넘기면") {
+            val cursorLikes = p1.likesCount
+            val cursorId = p1.id
+            val expectedIds = listOf(p2.id)
+
+            it("cursor 이후의 데이터만 반환한다") {
+                val result = productQueryService.getPopularProducts(
+                    categoryId = null,
+                    cursorLikes = cursorLikes,
+                    cursorId = cursorId,
+                    size = 10,
+                )
+                result.map { it.id } shouldContainExactly expectedIds
+            }
         }
 
-        it("카테고리 ID가 존재하지 않으면 빈 리스트") {
-            val list = productQueryService.getPopularProducts(categoryId = 999L, cursorId = null, size = 10)
-            list.shouldBeEmpty()
+        context("존재하지 않는 카테고리 ID를 넘기면") {
+            val missingCategoryId = 999L
+
+            it("빈 리스트를 반환한다") {
+                val result = productQueryService.getPopularProducts(
+                    categoryId = missingCategoryId,
+                    cursorLikes = null,
+                    cursorId = null,
+                    size = 10,
+                )
+                result.shouldBeEmpty()
+            }
         }
     }
 
     describe("getNewestProducts 메서드는") {
+        context("cursor 없이 요청하면") {
+            val expectedIds = listOf(p2.id, p1.id)
 
-        it("최근 30일 이내 상품만 반환하고 정렬은 id desc") {
-            val list = productQueryService.getNewestProducts(null, null, 10)
-            list.shouldContainExactly(p2, p1) // p2Id = 12, p1Id = 11
-            list.shouldBeSortedWith(compareByDescending { it.id })
+            it("최근 30일 이내 상품을 id DESC 로 반환한다") {
+                val result = productQueryService.getNewestProducts(
+                    categoryId = null,
+                    cursorId = null,
+                    size = 10,
+                )
+                result.map { it.id } shouldContainExactly expectedIds
+                result.shouldBeSortedWith(compareByDescending { it.id })
+            }
         }
 
-        it("cursor 페이징 동작 확인") {
-            val firstPage = productQueryService.getNewestProducts(null, null, 1) // p2
-            val nextPage = productQueryService.getNewestProducts(null, cursorId = firstPage.last().id, size = 10)
-            nextPage.shouldContainExactly(p1)
+        context("cursorId 를 넘기면") {
+            val cursorId = p2.id
+            val expectedId = listOf(p1.id)
+
+            it("cursor 이후 데이터만 반환한다") {
+                val result = productQueryService.getNewestProducts(
+                    categoryId = null,
+                    cursorId = cursorId,
+                    size = 10,
+                )
+
+                result.map { it.id } shouldContainExactly expectedId
+            }
         }
     }
 
     describe("getProductDetail 메서드는") {
+        context("존재하지 않는 id면") {
+            val nonExistentProductId = 404L
 
-        it("존재하지 않는 id면 EntityNotFoundException") {
-            shouldThrow<EntityNotFoundException> {
-                productQueryService.getProductDetail(404L)
+            it("IllegalArgumentException를 반환한다") {
+                shouldThrow<IllegalArgumentException> {
+                    productQueryService.getProductDetail(nonExistentProductId)
+                }.message shouldBe ErrorMessage.PRODUCT_NOT_FOUND.format(nonExistentProductId)
             }
         }
 
-        it("상세 조회 시 이미지·카테고리 fetch 확인") {
-            val detail = shouldNotThrowAny { productQueryService.getProductDetail(p1.id) }
-            detail.images.isNotEmpty() shouldBe true
-            detail.productCategories.first().category shouldBe top
+        context("상품 상세 조회 시") {
+            it("연관 엔티티(Images·Categories)를 fetch join 으로 즉시 로딩한다") {
+                val detail = shouldNotThrowAny { productQueryService.getProductDetail(p1.id) }
+                detail.images.isNotEmpty() shouldBe true
+                detail.productCategories.first().category.id shouldBe top.id
+            }
         }
     }
 })

--- a/src/test/kotlin/com/dh/baro/product/domain/ProductQueryServiceTest.kt
+++ b/src/test/kotlin/com/dh/baro/product/domain/ProductQueryServiceTest.kt
@@ -1,0 +1,95 @@
+package com.dh.baro.product.domain
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.assertions.throwables.shouldNotThrowAny
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.collections.shouldBeSortedWith
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.shouldBe
+import jakarta.persistence.EntityNotFoundException
+import org.junit.jupiter.api.DisplayName
+import org.springframework.boot.autoconfigure.domain.EntityScan
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories
+import org.springframework.test.context.ContextConfiguration
+import org.springframework.test.context.TestPropertySource
+
+@DataJpaTest
+@ContextConfiguration(classes = [ProductQueryService::class])
+@TestPropertySource("classpath:test.properties")
+@EntityScan("com.dh.baro.product.domain")
+@EnableJpaRepositories("com.dh.baro.product.domain")
+@DisplayName("ProductQueryService 클래스의")
+internal class ProductQueryServiceTest(
+    private val productQueryService: ProductQueryService,
+    private val productRepository: ProductRepository,
+    private val categoryRepository: CategoryRepository
+) : DescribeSpec({
+
+    lateinit var top: Category
+    lateinit var shoe: Category
+    lateinit var p1: Product;
+    lateinit var p2: Product;
+    lateinit var p3: Product
+
+    beforeEach {
+        top = categoryRepository.save(categoryFixture(1, "TOP"))
+        shoe = categoryRepository.save(categoryFixture(2, "SHOE"))
+
+        p1 = productRepository.save(productFixture(11, "T-Shirt", top, likes = 300))
+        p2 = productRepository.save(productFixture(12, "Hoodie", top, likes = 200))
+        p3 = productRepository.save(productFixture(21, "Sneakers", shoe, likes = 500, createdAtAgoDays = 31))
+    }
+
+    afterEach { productRepository.deleteAll() }
+
+    describe("getPopularProducts 메서드는") {
+
+        it("size 파라미터 만큼만 반환한다") {
+            val list = productQueryService.getPopularProducts(null, null, size = 1)
+            list.size shouldBe 1
+            list.first() shouldBe p1
+        }
+
+        it("cursorId 이후 데이터만 반환한다") {
+            val list = productQueryService.getPopularProducts(null, cursorId = p1.id, size = 10)
+            list.shouldContainExactly(p2, p3)
+        }
+
+        it("카테고리 ID가 존재하지 않으면 빈 리스트") {
+            val list = productQueryService.getPopularProducts(categoryId = 999L, cursorId = null, size = 10)
+            list.shouldBeEmpty()
+        }
+    }
+
+    describe("getNewestProducts 메서드는") {
+
+        it("최근 30일 이내 상품만 반환하고 정렬은 id desc") {
+            val list = productQueryService.getNewestProducts(null, null, 10)
+            list.shouldContainExactly(p2, p1) // p2Id = 12, p1Id = 11
+            list.shouldBeSortedWith(compareByDescending { it.id })
+        }
+
+        it("cursor 페이징 동작 확인") {
+            val firstPage = productQueryService.getNewestProducts(null, null, 1) // p2
+            val nextPage = productQueryService.getNewestProducts(null, cursorId = firstPage.last().id, size = 10)
+            nextPage.shouldContainExactly(p1)
+        }
+    }
+
+    describe("getProductDetail 메서드는") {
+
+        it("존재하지 않는 id면 EntityNotFoundException") {
+            shouldThrow<EntityNotFoundException> {
+                productQueryService.getProductDetail(404L)
+            }
+        }
+
+        it("상세 조회 시 이미지·카테고리 fetch 확인") {
+            val detail = shouldNotThrowAny { productQueryService.getProductDetail(p1.id) }
+            detail.images.isNotEmpty() shouldBe true
+            detail.productCategories.first().category shouldBe top
+        }
+    }
+})

--- a/src/test/kotlin/com/dh/baro/product/domain/ProductServiceTest.kt
+++ b/src/test/kotlin/com/dh/baro/product/domain/ProductServiceTest.kt
@@ -1,0 +1,61 @@
+package com.dh.baro.product.domain
+
+import com.dh.baro.product.application.ProductCreateCommand
+import io.kotest.assertions.throwables.shouldNotThrowAny
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.DisplayName
+import org.springframework.boot.autoconfigure.domain.EntityScan
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories
+import org.springframework.test.context.ContextConfiguration
+import org.springframework.test.context.TestPropertySource
+import java.math.BigDecimal
+
+@DataJpaTest
+@ContextConfiguration(classes = [ProductService::class])
+@TestPropertySource("classpath:test.properties")
+@EntityScan("com.dh.baro.product.domain")
+@EnableJpaRepositories("com.dh.baro.product.domain")
+@DisplayName("ProductService 클래스의")
+internal class ProductServiceTest(
+    private val productService: ProductService,
+    private val productRepository: ProductRepository,
+    private val categoryRepository: CategoryRepository,
+) : DescribeSpec({
+
+    lateinit var top: Category
+    lateinit var shoe: Category
+
+    beforeEach {
+        top = categoryRepository.save(Category(1L, "TOP"))
+        shoe = categoryRepository.save(Category(2L, "SHOE"))
+    }
+
+    afterEach {
+        productRepository.deleteAll()
+        categoryRepository.deleteAll()
+    }
+
+    describe("createProduct 메서드는") {
+        val cmd = ProductCreateCommand(
+            name = "Hoodie",
+            price = BigDecimal("59000"),
+            quantity = 10,
+            description = "Nice Hoodie",
+            likesCount = 0,
+            thumbnailUrl = "https://example.com/hoodie-thumb.jpg",
+        )
+
+        it("상품과 연결된 ProductCategory 를 모두 저장한다") {
+            val saved = shouldNotThrowAny {
+                productService.createProduct(cmd, listOf(top, shoe))
+            }
+            productRepository.existsById(saved.id) shouldBe true
+
+            val categoryIds = saved.productCategories.map { it.category.id }
+            categoryIds.shouldContainExactlyInAnyOrder(listOf(top.id, shoe.id))
+        }
+    }
+})

--- a/src/test/resources/test.properties
+++ b/src/test/resources/test.properties
@@ -1,0 +1,18 @@
+spring.profiles.active=test
+
+spring.datasource.driver-class-name = org.h2.Driver
+spring.datasource.url = jdbc:h2:mem:test;MODE=MySQL;DATABASE_TO_LOWER=TRUE
+
+spring.jpa.hibernated.ddl-auto = create-drop
+spring.jpa.database-platform = org.hibernate.dialect.H2Dialect
+
+spring.datasource.hikari.maximum-pool-size = 4
+spring.datasource.hikari.pool-name = H2_TEST_POOL
+
+### FOR DEBUGGING ###
+logging.level.org.hibernate.SQL = debug
+logging.level.org.hibernate.type.descriptor.sql = trace
+
+spring.jpa.properties.hibernate.format_sql = true
+spring.jpa.properties.hibernate.highlight_sql = true
+spring.jpa.properties.hibernate.use_sql_comments = true


### PR DESCRIPTION
## Issue Number

## As-Is
<!-- Describe the current issue or problem -->
- 상품 도메인에 대한 CRUD, 페이징 기반 API가 미구현되어 있었음
- 연관 관계(카테고리, 이미지) fetch 전략 및 응답 구조 정의 미흡
- 커서 기반 페이징 구조 및 일관된 응답 포맷 부재
- 테스트 커버리지가 낮고, 단일 케이스 중심으로 작성되어 있었음

## To-Be
<!-- Describe the intended changes or improvements -->

### 1. 상품 목록/상세/생성 기능 구현

* `/products` POST API: 상품 생성 로직 구현 (`ProductFacade`, `ProductService`, `ProductCreateCommand`)
* `/products/popular`, `/products/newest`: 인기순/최신순 상품 커서 페이징 기반 조회 구현
* 상세 조회 시 연관된 이미지·카테고리를 fetch join 처리하여 N+1 방지

### 2. 커서 기반 페이징 설계 및 응답 포맷 통합

* 인기순: `cursorLikes`, `cursorId` 기반 커서 처리
* 최신순: `cursorId` 기반 커서 처리
* 응답: `SliceResponse<T>`로 공통 포맷 정의 (content, hasNext, nextCursor)
* 커서 DTO 분리: `Cursor`, `PopularCursor` 활용

### 3. ErrorMessage 추가

* `PRODUCT_NOT_FOUND`, `CATEGORY_ALREADY_EXISTS`, `INVALID_POPULAR_PRODUCT_CURSOR` 등 도메인별 메시지 적용

### 4. 테스트 코드 작성 (Kotest 기반 DescribeSpec + DCI 패턴)

* Kotest의 `DescribeSpec`을 활용한 DCI 패턴 구조의 테스트 작성
* 목적 중심 테스트 시나리오 구성 (context + it)

  * 상품 생성 → `ProductServiceTest`
  * 목록/상세 조회 및 페이징 → `ProductQueryServiceTest`
  * 카테고리 등록 및 존재 여부 검증 → `CategoryServiceTest`
* `Slice`, `SliceResponse` 구조 테스트 포함 (hasNext, nextCursor 검증)

---

### 📌 기타

* `MultipleBagFetchException` 회피를 위해 `List` → `Set` 변경
* ID 생성 방식 통일 (`IdGenerator.generate()` 활용)
* 응답 DTO 분리 (`ProductResponse`, `ProductListItem`, `ProductDetail`, `CategoryResponse` 등)


## ✅ Check List

- [x] Have all tests passed?
- [x] Have all commits been pushed?
- [x] Did you verify the target branch for the merge?
- [x] Did you assign the appropriate assignee(s)?
- [x] Did you set the correct label(s)?

## 📸 Test Screenshot

## Additional Description
