### PR TITLE
[FEAT] Store 도메인 생성 및 예외 처리 구조 개선

### DIFF
--- a/gradle/spring.gradle
+++ b/gradle/spring.gradle
@@ -4,6 +4,7 @@ jar {
 
 dependencies {
     implementation "org.springframework.boot:spring-boot-starter-web"
+    implementation("org.springframework.boot:spring-boot-starter-validation")
     implementation "org.springframework.boot:spring-boot-starter-aop"
     implementation "org.springframework.boot:spring-boot-starter-data-jpa"
     implementation "org.springframework.boot:spring-boot-starter-data-redis"

--- a/src/main/kotlin/com/dh/baro/core/ErrorMessage.kt
+++ b/src/main/kotlin/com/dh/baro/core/ErrorMessage.kt
@@ -5,7 +5,15 @@ enum class ErrorMessage(val message: String) {
     // Common
     UNAUTHORIZED("로그인이 필요합니다."),
     FORBIDDEN("권한이 없습니다."),
+    INVALID_JSON("잘못된 JSON 형식입니다. 요청 데이터를 확인하세요."),
+    FIELD_ERROR("요청 본문 필드 검증에 실패했습니다."),
+    URL_PARAMETER_ERROR("요청 URL 파라미터 검증에 실패했습니다."),
+    MISSING_REQUEST_HEADER("필수 요청 헤더가 누락되었습니다"),
+    METHOD_ARGUMENT_TYPE_MISMATCH("요청 파라미터 타입이 올바르지 않습니다."),
+    ALREADY_DISCONNECTED("클라이언트 연결이 중단되었습니다."),
     NO_RESOURCE_FOUND("요청한 리소스를 찾을 수 없습니다."),
+    METHOD_NOT_SUPPORTED("허용되지 않은 메서드입니다."),
+    MEDIA_TYPE_NOT_SUPPORTED("허용되지 않은 미디어 타입입니다."),
     UNHANDLED_EXCEPTION("서버 오류가 발생했습니다. 관리자에게 문의해주세요."),
 
     // Identity

--- a/src/main/kotlin/com/dh/baro/core/ErrorResponse.kt
+++ b/src/main/kotlin/com/dh/baro/core/ErrorResponse.kt
@@ -1,11 +1,75 @@
 package com.dh.baro.core
 
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.annotation.JsonInclude.Include
+import jakarta.validation.ConstraintViolation
+import jakarta.validation.Path
+import org.springframework.validation.BindingResult
+
+@JsonInclude(Include.NON_NULL)
 data class ErrorResponse(
     val message: String,
+    val fieldErrors: List<FieldError>? = null,
+    val violationErrors: List<ViolationError>? = null,
 ) {
 
     companion object {
+        fun from(errorMessage: ErrorMessage): ErrorResponse =
+            ErrorResponse(message = errorMessage.message)
+
         fun from(exception: Exception): ErrorResponse =
-            ErrorResponse(exception.message ?: exception.localizedMessage)
+            ErrorResponse(message = exception.message ?: exception.localizedMessage ?: "Unexpected error")
+
+        fun from(errorMessage: ErrorMessage, bindingResult: BindingResult): ErrorResponse =
+            ErrorResponse(
+                message = errorMessage.message,
+                fieldErrors = FieldError.from(bindingResult),
+            )
+
+        fun from(errorMessage: ErrorMessage, violations: Set<ConstraintViolation<*>>): ErrorResponse =
+            ErrorResponse(
+                message = errorMessage.message,
+                violationErrors = ViolationError.from(violations),
+            )
+    }
+
+    data class FieldError(
+        val field: String,
+        val rejectedValue: Any?,
+        val reason: String?,
+    ) {
+        companion object {
+            fun from(bindingResult: BindingResult): List<FieldError> =
+                bindingResult.fieldErrors.map { e ->
+                    FieldError(
+                        field = e.field,
+                        rejectedValue = e.rejectedValue,
+                        reason = e.defaultMessage,
+                    )
+                }
+        }
+    }
+
+    data class ViolationError(
+        val field: String,
+        val rejectedValue: Any?,
+        val reason: String?,
+    ) {
+        companion object {
+            fun from(violations: Set<ConstraintViolation<*>>): List<ViolationError> =
+                violations.map { v ->
+                    ViolationError(
+                        field = v.propertyPath.leafName(),
+                        rejectedValue = v.invalidValue,
+                        reason = v.message,
+                    )
+                }
+
+            private fun Path.leafName(): String =
+                this.iterator().asSequence()
+                    .mapNotNull { it.name }
+                    .lastOrNull()
+                    ?: this.toString()
+        }
     }
 }

--- a/src/main/kotlin/com/dh/baro/core/advice/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/com/dh/baro/core/advice/GlobalExceptionHandler.kt
@@ -4,12 +4,21 @@ import com.dh.baro.core.ErrorMessage
 import com.dh.baro.core.ErrorResponse
 import com.dh.baro.core.exception.ForbiddenException
 import com.dh.baro.core.exception.UnauthorizedException
+import jakarta.validation.ConstraintViolationException
+import org.apache.catalina.connector.ClientAbortException
 import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus
+import org.springframework.http.converter.HttpMessageNotReadableException
+import org.springframework.validation.BindException
+import org.springframework.web.HttpMediaTypeNotSupportedException
+import org.springframework.web.HttpRequestMethodNotSupportedException
+import org.springframework.web.bind.MethodArgumentNotValidException
 import org.springframework.web.bind.MissingRequestHeaderException
+import org.springframework.web.bind.MissingServletRequestParameterException
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestControllerAdvice
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException
 import org.springframework.web.servlet.resource.NoResourceFoundException
 
 @RestControllerAdvice
@@ -17,48 +26,126 @@ class GlobalExceptionHandler {
 
     private val logger = LoggerFactory.getLogger(this::class.simpleName)
 
+    // Body 검증
+    @ExceptionHandler(MethodArgumentNotValidException::class)
     @ResponseStatus(HttpStatus.BAD_REQUEST)
+    fun handleMethodArgumentNotValid(e: MethodArgumentNotValidException): ErrorResponse {
+        logger.info(e.message)
+        return ErrorResponse.from(ErrorMessage.FIELD_ERROR, e.bindingResult)
+    }
+
+    // ModelAttribute 바인딩/검증
+    @ExceptionHandler(BindException::class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    fun handleBindException(e: BindException): ErrorResponse {
+        logger.info(e.message)
+        return ErrorResponse.from(ErrorMessage.FIELD_ERROR, e.bindingResult)
+    }
+
+    // Query/Path 파라미터 검증
+    @ExceptionHandler(ConstraintViolationException::class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    fun handleConstraintViolation(e: ConstraintViolationException): ErrorResponse {
+        logger.info(e.message)
+        return ErrorResponse.from(ErrorMessage.URL_PARAMETER_ERROR, e.constraintViolations)
+    }
+
+    // 필수 파라미터 누락
+    @ExceptionHandler(MissingServletRequestParameterException::class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    fun handleMissingServletRequestParameter(e: MissingServletRequestParameterException): ErrorResponse {
+        logger.info(e.message)
+        return ErrorResponse.from(ErrorMessage.URL_PARAMETER_ERROR)
+    }
+
+    // 필수 헤더 누락
     @ExceptionHandler(MissingRequestHeaderException::class)
-    fun handleMissingRequestHeaderException(exception: MissingRequestHeaderException): ErrorResponse =
-        ErrorResponse.from(exception)
-
     @ResponseStatus(HttpStatus.BAD_REQUEST)
+    fun handleMissingRequestHeader(e: MissingRequestHeaderException): ErrorResponse {
+        logger.info(e.message)
+        return ErrorResponse.from(ErrorMessage.MISSING_REQUEST_HEADER)
+    }
+
+    // 파라미터 타입 불일치
+    @ExceptionHandler(MethodArgumentTypeMismatchException::class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    fun handleMethodArgumentTypeMismatch(e: MethodArgumentTypeMismatchException): ErrorResponse {
+        logger.info(e.message)
+        return ErrorResponse.from(ErrorMessage.METHOD_ARGUMENT_TYPE_MISMATCH)
+    }
+
+    // 클라이언트 전송 중단
+    @ExceptionHandler(ClientAbortException::class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    fun handleClientAbort(e: ClientAbortException): ErrorResponse {
+        logger.info(e.message)
+        return ErrorResponse.from(ErrorMessage.ALREADY_DISCONNECTED)
+    }
+
+    // JSON 파싱 오류 등
+    @ExceptionHandler(HttpMessageNotReadableException::class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    fun handleHttpMessageNotReadable(e: HttpMessageNotReadableException): ErrorResponse {
+        logger.info(e.message)
+        return ErrorResponse.from(ErrorMessage.INVALID_JSON)
+    }
+
+    // 비즈니스 검증 실패
     @ExceptionHandler(IllegalArgumentException::class)
-    fun handleIllegalArgumentException(exception: IllegalArgumentException): ErrorResponse {
-        logger.info(exception.message, exception)
-        return ErrorResponse.from(exception)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    fun handleIllegalArgument(e: IllegalArgumentException): ErrorResponse {
+        logger.info(e.message)
+        return ErrorResponse.from(e)
     }
 
-    @ResponseStatus(HttpStatus.FORBIDDEN)
-    @ExceptionHandler(ForbiddenException::class)
-    fun handleForbiddenException(exception: ForbiddenException): ErrorResponse {
-        logger.warn("[Forbidden] : ${exception.message}", exception)
-        return ErrorResponse.from(exception)
-    }
-
-    @ResponseStatus(HttpStatus.UNAUTHORIZED)
     @ExceptionHandler(UnauthorizedException::class)
-    fun handleUnauthorizedException(exception: UnauthorizedException): ErrorResponse {
-        logger.warn("[Unauthorized] : ${exception.message}", exception)
-        return ErrorResponse.from(exception)
+    @ResponseStatus(HttpStatus.UNAUTHORIZED)
+    fun handleUnauthorized(e: UnauthorizedException): ErrorResponse {
+        logger.warn("[Unauthorized] : ${e.message}", e)
+        return ErrorResponse.from(e)
+    }
+
+    @ExceptionHandler(ForbiddenException::class)
+    @ResponseStatus(HttpStatus.FORBIDDEN)
+    fun handleForbidden(e: ForbiddenException): ErrorResponse {
+        logger.warn("[Forbidden] : ${e.message}", e)
+        return ErrorResponse.from(e)
     }
 
     @ExceptionHandler(NoResourceFoundException::class)
     @ResponseStatus(HttpStatus.NOT_FOUND)
-    fun handleNoResourceFoundException(noResourceFoundException: NoResourceFoundException): ErrorResponse =
-        ErrorResponse(ErrorMessage.NO_RESOURCE_FOUND.message)
+    fun handleNoResourceFound(e: NoResourceFoundException): ErrorResponse {
+        logger.info(e.message)
+        return ErrorResponse(ErrorMessage.NO_RESOURCE_FOUND.message)
+    }
 
-    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    // 지원하지 않는 메서드 호출
+    @ExceptionHandler(HttpRequestMethodNotSupportedException::class)
+    @ResponseStatus(HttpStatus.METHOD_NOT_ALLOWED)
+    fun handleMethodNotSupported(e: HttpRequestMethodNotSupportedException): ErrorResponse {
+        logger.info(e.message)
+        return ErrorResponse(ErrorMessage.METHOD_NOT_SUPPORTED.message)
+    }
+
+    // 서버가 지원하지 않는 미디어 타입
+    @ExceptionHandler(HttpMediaTypeNotSupportedException::class)
+    @ResponseStatus(HttpStatus.UNSUPPORTED_MEDIA_TYPE)
+    fun handleMediaTypeNotSupported(e: HttpMediaTypeNotSupportedException): ErrorResponse {
+        logger.info(e.message)
+        return ErrorResponse(ErrorMessage.MEDIA_TYPE_NOT_SUPPORTED.message)
+    }
+
     @ExceptionHandler(IllegalStateException::class)
-    fun handleIllegalStateException(exception: IllegalStateException): ErrorResponse {
-        logger.error(exception.message, exception)
-        return ErrorResponse.from(exception)
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    fun handleIllegalState(e: IllegalStateException): ErrorResponse {
+        logger.error(e.message, e)
+        return ErrorResponse.from(e)
     }
 
     @ExceptionHandler(Exception::class)
     @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
-    fun handleAllUnHandledException(exception: Exception): ErrorResponse {
-        logger.error(exception.message, exception)
-        return ErrorResponse(ErrorMessage.UNHANDLED_EXCEPTION.message)
+    fun handleUnhandled(e: Exception): ErrorResponse {
+        logger.error(e.message, e)
+        return ErrorResponse.from(ErrorMessage.UNHANDLED_EXCEPTION)
     }
 }

--- a/src/main/kotlin/com/dh/baro/identity/domain/Store.kt
+++ b/src/main/kotlin/com/dh/baro/identity/domain/Store.kt
@@ -1,0 +1,72 @@
+package com.dh.baro.identity.domain
+
+import com.dh.baro.core.AbstractTime
+import com.dh.baro.core.IdGenerator
+import jakarta.persistence.*
+
+@Entity
+@Table(name = "stores")
+class Store(
+    @Id
+    @Column(name = "id")
+    val id: Long,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "owner_id", nullable = false)
+    val owner: User,
+
+    @Column(name = "store_name", nullable = false, length = 100)
+    private var name: String,
+
+    @Lob
+    @Column(name = "description", columnDefinition = "MEDIUMTEXT")
+    private var description: String? = null,
+
+    @Column(name = "phone_number", length = 30)
+    private var phoneNumber: String? = null,
+
+    @Column(name = "address", length = 500)
+    private var address: String? = null,
+
+    @Column(name = "thumbnail_url", length = 300)
+    private var thumbnailUrl: String? = null,
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "store_status", nullable = false, length = 20)
+    private var status: StoreStatus = StoreStatus.DRAFT,
+) : AbstractTime() {
+
+    fun getName(): String = name
+
+    fun getDescription(): String? = description
+
+    fun getPhoneNumber(): String? = phoneNumber
+
+    fun getAddress(): String? = address
+
+    fun getThumbnailUrl(): String? = thumbnailUrl
+
+    fun getStatus(): StoreStatus = status
+
+    companion object {
+        fun newStore(
+            owner: User,
+            name: String,
+            description: String?,
+            phoneNumber: String?,
+            address: String?,
+            thumbnailUrl: String?,
+        ): Store {
+            return Store(
+                id = IdGenerator.generate(),
+                owner = owner,
+                name = name.trim(),
+                description = description,
+                phoneNumber = phoneNumber,
+                address = address,
+                thumbnailUrl = thumbnailUrl,
+                status = StoreStatus.DRAFT,
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/dh/baro/identity/domain/StoreStatus.kt
+++ b/src/main/kotlin/com/dh/baro/identity/domain/StoreStatus.kt
@@ -1,0 +1,10 @@
+package com.dh.baro.identity.domain
+
+enum class StoreStatus {
+    DRAFT,
+    ACTIVE,
+    PAUSED,
+    SUSPENDED,
+    CLOSED,
+    TERMINATED,
+}

--- a/src/main/kotlin/com/dh/baro/identity/domain/User.kt
+++ b/src/main/kotlin/com/dh/baro/identity/domain/User.kt
@@ -13,13 +13,13 @@ class User(
     @Column(name = "id")
     val id: Long,
 
-    @Column(name = "user_name", nullable = false)
+    @Column(name = "user_name", nullable = false, length = 100)
     private var name: String,
 
     @Column(name = "email", nullable = false, unique = true)
     private var email: String,
 
-    @Column(name = "phone_number", unique = true)
+    @Column(name = "phone_number", unique = true, length = 30)
     private var phoneNumber: String? = null,
 
     @Column(name = "address", length = 500)
@@ -50,7 +50,7 @@ class User(
         fun newUser(name: String, email: String): User {
             return User(
                 id = IdGenerator.generate(),
-                name = name,
+                name = name.trim(),
                 email = email,
             )
         }

--- a/src/main/kotlin/com/dh/baro/look/domain/Look.kt
+++ b/src/main/kotlin/com/dh/baro/look/domain/Look.kt
@@ -1,11 +1,13 @@
 package com.dh.baro.look.domain
 
 import com.dh.baro.core.AbstractTime
+import com.dh.baro.core.AggregateRoot
 import com.dh.baro.core.IdGenerator
 import com.dh.baro.look.domain.vo.LookImageView
 import com.dh.baro.look.domain.vo.LookProductView
 import jakarta.persistence.*
 
+@AggregateRoot
 @Entity
 @Table(name = "looks")
 class Look(

--- a/src/main/kotlin/com/dh/baro/order/domain/Order.kt
+++ b/src/main/kotlin/com/dh/baro/order/domain/Order.kt
@@ -1,11 +1,13 @@
 package com.dh.baro.order.domain
 
 import com.dh.baro.core.AbstractTime
+import com.dh.baro.core.AggregateRoot
 import com.dh.baro.core.IdGenerator
 import jakarta.persistence.*
 import java.math.BigDecimal
 import java.math.RoundingMode
 
+@AggregateRoot
 @Entity
 @Table(name = "orders")
 class Order(
@@ -23,10 +25,15 @@ class Order(
     var shippingAddress: String,
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "status", nullable = false, length = 20)
+    @Column(name = "order_status", nullable = false, length = 20)
     var status: OrderStatus = OrderStatus.ORDERED,
 
-    @OneToMany(mappedBy = "order", cascade = [CascadeType.ALL], orphanRemoval = true)
+    @OneToMany(
+        mappedBy = "order",
+        fetch = FetchType.LAZY,
+        cascade = [CascadeType.ALL],
+        orphanRemoval = true,
+    )
     val items: MutableSet<OrderItem> = mutableSetOf()
 ) : AbstractTime() {
 

--- a/src/main/kotlin/com/dh/baro/product/application/ProductCreateCommand.kt
+++ b/src/main/kotlin/com/dh/baro/product/application/ProductCreateCommand.kt
@@ -4,6 +4,7 @@ import java.math.BigDecimal
 
 data class ProductCreateCommand(
     val name: String,
+    val storeId: Long,
     val price: BigDecimal,
     val quantity: Int,
     val description: String?,

--- a/src/main/kotlin/com/dh/baro/product/domain/Product.kt
+++ b/src/main/kotlin/com/dh/baro/product/domain/Product.kt
@@ -15,6 +15,9 @@ class Product(
     @Column(name = "id")
     val id: Long,
 
+    @Column(name = "store_id", nullable = false)
+    val storeId: Long,
+
     @Column(name = "product_name", nullable = false, length = 100)
     private var name: String,
 
@@ -49,8 +52,7 @@ class Product(
         fetch = FetchType.LAZY
     )
     private val productCategories: MutableSet<ProductCategory> = mutableSetOf(),
-
-    ) : AbstractTime() {
+) : AbstractTime() {
 
     fun getName(): String = name
 
@@ -109,6 +111,7 @@ class Product(
     companion object {
         fun newProduct(
             name: String,
+            storeId: Long,
             price: BigDecimal,
             quantity: Int,
             thumbnailUrl: String,
@@ -117,6 +120,7 @@ class Product(
         ): Product =
             Product(
                 id = IdGenerator.generate(),
+                storeId = storeId,
                 name = name,
                 price = price,
                 quantity = quantity,

--- a/src/main/kotlin/com/dh/baro/product/domain/service/ProductService.kt
+++ b/src/main/kotlin/com/dh/baro/product/domain/service/ProductService.kt
@@ -16,6 +16,7 @@ class ProductService(
     fun createProduct(cmd: ProductCreateCommand, categories: List<Category>): Product {
         val product = Product.newProduct(
             name = cmd.name,
+            storeId = cmd.storeId,
             price = cmd.price,
             quantity = cmd.quantity,
             description = cmd.description,

--- a/src/main/kotlin/com/dh/baro/product/presentation/ProductController.kt
+++ b/src/main/kotlin/com/dh/baro/product/presentation/ProductController.kt
@@ -25,7 +25,6 @@ class ProductController(
     @ResponseStatus(HttpStatus.CREATED)
     @CheckAuth(UserRole.STORE_OWNER)
     override fun createProduct(
-        @CurrentUser userId: Long,
         @Valid @RequestBody request: ProductCreateRequest,
     ): ProductCreateResponse =
         ProductCreateResponse.from(productFacade.createProduct(request.toCommand()))

--- a/src/main/kotlin/com/dh/baro/product/presentation/ProductController.kt
+++ b/src/main/kotlin/com/dh/baro/product/presentation/ProductController.kt
@@ -4,6 +4,7 @@ import com.dh.baro.core.Cursor
 import com.dh.baro.core.ErrorMessage
 import com.dh.baro.core.SliceResponse
 import com.dh.baro.core.auth.CheckAuth
+import com.dh.baro.core.auth.CurrentUser
 import com.dh.baro.identity.domain.UserRole
 import com.dh.baro.product.application.ProductFacade
 import com.dh.baro.product.domain.service.ProductQueryService
@@ -23,7 +24,10 @@ class ProductController(
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
     @CheckAuth(UserRole.STORE_OWNER)
-    override fun createProduct(@Valid @RequestBody request: ProductCreateRequest): ProductCreateResponse =
+    override fun createProduct(
+        @CurrentUser userId: Long,
+        @Valid @RequestBody request: ProductCreateRequest,
+    ): ProductCreateResponse =
         ProductCreateResponse.from(productFacade.createProduct(request.toCommand()))
 
     @GetMapping("/popular")

--- a/src/main/kotlin/com/dh/baro/product/presentation/dto/ProductCreateRequest.kt
+++ b/src/main/kotlin/com/dh/baro/product/presentation/dto/ProductCreateRequest.kt
@@ -9,6 +9,9 @@ data class ProductCreateRequest(
     val name: String,
 
     @field:Positive
+    val storeId: Long,
+
+    @field:Positive
     val price: BigDecimal,
 
     @field:PositiveOrZero
@@ -31,6 +34,7 @@ data class ProductCreateRequest(
     fun toCommand(): ProductCreateCommand =
         ProductCreateCommand(
             name = name,
+            storeId = storeId,
             price = price,
             quantity = quantity,
             description = description,

--- a/src/main/kotlin/com/dh/baro/product/presentation/swagger/ProductSwagger.kt
+++ b/src/main/kotlin/com/dh/baro/product/presentation/swagger/ProductSwagger.kt
@@ -55,7 +55,6 @@ interface ProductSwagger {
     )
     @PostMapping
     fun createProduct(
-        userId: Long,
         @RequestBody request: ProductCreateRequest,
     ): ProductCreateResponse
 

--- a/src/main/kotlin/com/dh/baro/product/presentation/swagger/ProductSwagger.kt
+++ b/src/main/kotlin/com/dh/baro/product/presentation/swagger/ProductSwagger.kt
@@ -33,12 +33,14 @@ interface ProductSwagger {
                     value = """
                     {
                       "name": "T-Shirt",
+                      "storeId": 123,
                       "price": 19900,
                       "quantity": 100,
                       "description": "면 100% 기본 티셔츠",
                       "likesCount": 0,
                       "thumbnailUrl": "https://example.com/11-thumb.jpg",
-                      "categoryIds": [1, 2]
+                      "categoryIds": [1, 2],
+                      "imageUrls": ["https://example.com/11-thumb.jpg"]
                     }
                     """
                 )]
@@ -52,7 +54,10 @@ interface ProductSwagger {
         ]
     )
     @PostMapping
-    fun createProduct(@RequestBody request: ProductCreateRequest): ProductCreateResponse
+    fun createProduct(
+        userId: Long,
+        @RequestBody request: ProductCreateRequest,
+    ): ProductCreateResponse
 
     /* ───────────────────────────── 인기 상품 ───────────────────────────── */
     @Operation(

--- a/src/test/kotlin/com/dh/baro/order/Fixture.kt
+++ b/src/test/kotlin/com/dh/baro/order/Fixture.kt
@@ -16,6 +16,7 @@ fun productFixture(
     Product(
         id = id,
         name = name,
+        storeId = 123L,
         price = price,
         quantity = quantity,
         thumbnailUrl = "https://example.com/$id-thumb.jpg",

--- a/src/test/kotlin/com/dh/baro/product/domain/Fixture.kt
+++ b/src/test/kotlin/com/dh/baro/product/domain/Fixture.kt
@@ -17,6 +17,7 @@ fun productFixture(
     val product = Product(
         id = id,
         name = name,
+        storeId = 123L,
         price = BigDecimal("19900"),
         quantity = 10,
         thumbnailUrl = "https://example.com/$id-thumb.jpg",

--- a/src/test/kotlin/com/dh/baro/product/domain/ProductServiceTest.kt
+++ b/src/test/kotlin/com/dh/baro/product/domain/ProductServiceTest.kt
@@ -44,6 +44,7 @@ internal class ProductServiceTest(
     describe("createProduct 메서드는") {
         val cmd = ProductCreateCommand(
             name = "Hoodie",
+            storeId = 123L,
             price = BigDecimal("59000"),
             quantity = 10,
             description = "Nice Hoodie",


### PR DESCRIPTION
## Issue Number
#18 

## As-Is

* `Store` 관련 도메인이 존재하지 않아 매장 관리 기능 개발이 불가능했음
* 공통 예외 처리 로직이 부족하여 다양한 예외에 대한 일관된 응답 제공이 어려웠음
* `ErrorResponse`가 단순 문자열 메시지 형태로만 구성되어 있어 입력 검증 상세 정보를 클라이언트에 제공할 수 없었음

## To-Be

* `Store` 엔티티 도메인 및 상태(enum) 정의

  * `User`와 연관된 매장 정보를 관리하기 위한 `Store` 엔티티 생성
  * 매장 상태를 표현하기 위한 `StoreStatus` enum 도입
  * 생성 시 `DRAFT` 상태로 초기화되는 정적 팩토리 메서드 추가

* 검증/예외 응답 구조 고도화

  * `ErrorResponse`를 확장하여 `fieldErrors`, `violationErrors` 등 구조적 오류 응답 포맷 지원
  * `BindingResult`, `ConstraintViolationException` 기반 오류에 대한 명확한 필드 응답 제공

* 예외 처리 전면 개선

  * `HttpMessageNotReadableException`, `BindException`, `MethodArgumentTypeMismatchException` 등 추가 대응
  * 클라이언트 전송 중단 및 잘못된 요청에 대한 구체적인 로그 및 메시지 반환

* `ErrorMessage` enum 확장

  * 공통 예외 메시지 (`INVALID_JSON`, `FIELD_ERROR`, `METHOD_NOT_SUPPORTED`, `ALREADY_DISCONNECTED` 등) 항목 추가

## ✅ Check List

- [x] Have all tests passed?
- [x] Have all commits been pushed?
- [x] Did you verify the target branch for the merge?
- [x] Did you assign the appropriate assignee(s)?
- [x] Did you set the correct label(s)?

## 📸 Test Screenshot

## Additional Description
