### PR TITLE
[FEAT] Look·Product 응답에 storeName 포함 및 응답 구조 리팩토링

### DIFF
--- a/src/main/kotlin/com/dh/baro/core/ErrorMessage.kt
+++ b/src/main/kotlin/com/dh/baro/core/ErrorMessage.kt
@@ -18,6 +18,7 @@ enum class ErrorMessage(val message: String) {
 
     // Identity
     USER_NOT_FOUND("사용자를 찾을 수 없습니다: %d"),
+    STORE_NOT_FOUND("스토어를 찾을 수 없습니다: %d"),
     UNSUPPORTED_SOCIAL_LOGIN("지원하지 않는 소셜 로그인 제공자입니다: %s"),
     KAKAO_USER_FETCH_FAILED("카카오 사용자 정보 조회 실패: %s"),
 

--- a/src/main/kotlin/com/dh/baro/core/SliceResponse.kt
+++ b/src/main/kotlin/com/dh/baro/core/SliceResponse.kt
@@ -19,5 +19,16 @@ data class SliceResponse<T>(
                 hasNext = slice.hasNext(),
                 nextCursor = slice.content.lastOrNull()?.let(cursorExtractor),
             )
+
+        fun <T, R> fromNullable(
+            slice: Slice<T>,
+            mapper: (T) -> R?,
+            cursorExtractor: (T) -> Any,
+        ): SliceResponse<R> =
+            SliceResponse(
+                content = slice.content.mapNotNull(mapper),
+                hasNext = slice.hasNext(),
+                nextCursor = slice.content.lastOrNull()?.let(cursorExtractor),
+            )
     }
 }

--- a/src/main/kotlin/com/dh/baro/identity/domain/repository/StoreRepository.kt
+++ b/src/main/kotlin/com/dh/baro/identity/domain/repository/StoreRepository.kt
@@ -1,0 +1,6 @@
+package com.dh.baro.identity.domain.repository
+
+import com.dh.baro.identity.domain.Store
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface StoreRepository : JpaRepository<Store, Long>

--- a/src/main/kotlin/com/dh/baro/identity/domain/service/StoreService.kt
+++ b/src/main/kotlin/com/dh/baro/identity/domain/service/StoreService.kt
@@ -1,0 +1,24 @@
+package com.dh.baro.identity.domain.service
+
+import com.dh.baro.core.ErrorMessage
+import com.dh.baro.identity.domain.Store
+import com.dh.baro.identity.domain.repository.StoreRepository
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+@Transactional(readOnly = true)
+class StoreService(
+    private val storeRepository: StoreRepository,
+) {
+
+    fun getStoresByIds(storeIds: Collection<Long>): List<Store> {
+        if (storeIds.isEmpty()) return emptyList()
+        return storeRepository.findAllById(storeIds).toList()
+    }
+
+    fun getStoreById(storeId: Long): Store =
+        storeRepository.findByIdOrNull(storeId)
+            ?: throw IllegalArgumentException(ErrorMessage.STORE_NOT_FOUND.message.format(storeId))
+}

--- a/src/main/kotlin/com/dh/baro/look/application/dto/LookDetailBundle.kt
+++ b/src/main/kotlin/com/dh/baro/look/application/dto/LookDetailBundle.kt
@@ -1,0 +1,12 @@
+package com.dh.baro.look.application.dto
+
+import com.dh.baro.identity.domain.Store
+import com.dh.baro.look.domain.Look
+import com.dh.baro.product.domain.Product
+
+data class LookDetailBundle (
+    val look: Look,
+    val orderedProductIds: List<Long>,
+    val products: List<Product>,
+    val stores: List<Store>,
+)

--- a/src/main/kotlin/com/dh/baro/look/domain/Look.kt
+++ b/src/main/kotlin/com/dh/baro/look/domain/Look.kt
@@ -3,8 +3,6 @@ package com.dh.baro.look.domain
 import com.dh.baro.core.AbstractTime
 import com.dh.baro.core.AggregateRoot
 import com.dh.baro.core.IdGenerator
-import com.dh.baro.look.domain.vo.LookImageView
-import com.dh.baro.look.domain.vo.LookProductView
 import jakarta.persistence.*
 
 @AggregateRoot
@@ -56,16 +54,16 @@ class Look(
 
     fun getThumbnailUrl() = thumbnailUrl
 
-    fun getOrderedImageViews(): List<LookImageView> =
-        images.asSequence()
-            .sortedBy { it.displayOrder }
-            .map { LookImageView(it.imageUrl, it.displayOrder) }
-            .toList()
-
-    fun getOrderedProductViews(): List<LookProductView> =
+    fun getOrderedProductIds(): List<Long> =
         products.asSequence()
             .sortedBy { it.displayOrder }
-            .map { LookProductView(it.productId, it.displayOrder) }
+            .map { it.productId }
+            .toList()
+
+    fun getOrderedImageUrls(): List<String> =
+        images.asSequence()
+            .sortedBy { it.displayOrder }
+            .map { it.imageUrl }
             .toList()
 
     fun addImages(imageUrls: List<String>) {

--- a/src/main/kotlin/com/dh/baro/look/domain/vo/LookImageView.kt
+++ b/src/main/kotlin/com/dh/baro/look/domain/vo/LookImageView.kt
@@ -1,6 +1,0 @@
-package com.dh.baro.look.domain.vo
-
-data class LookImageView(
-    val imageUrl: String,
-    val displayOrder: Int,
-)

--- a/src/main/kotlin/com/dh/baro/look/domain/vo/LookProductView.kt
+++ b/src/main/kotlin/com/dh/baro/look/domain/vo/LookProductView.kt
@@ -1,6 +1,0 @@
-package com.dh.baro.look.domain.vo
-
-data class LookProductView(
-    val productId: Long,
-    val displayOrder: Int,
-)

--- a/src/main/kotlin/com/dh/baro/look/presentation/LookController.kt
+++ b/src/main/kotlin/com/dh/baro/look/presentation/LookController.kt
@@ -62,6 +62,8 @@ class LookController(
 
     @GetMapping("/{lookId}")
     @ResponseStatus(HttpStatus.OK)
-    override fun getLookDetail(@PathVariable lookId: Long): LookDetailResponse =
-        lookFacade.getLookDetail(lookId)
+    override fun getLookDetail(@PathVariable lookId: Long): LookDetailResponse {
+        val lookDetailBundle = lookFacade.getLookDetail(lookId)
+        return LookDetailResponse.from(lookDetailBundle)
+    }
 }

--- a/src/main/kotlin/com/dh/baro/product/application/ProductFacade.kt
+++ b/src/main/kotlin/com/dh/baro/product/application/ProductFacade.kt
@@ -1,18 +1,51 @@
 package com.dh.baro.product.application
 
+import com.dh.baro.identity.domain.service.StoreService
+import com.dh.baro.product.application.dto.ProductDetailBundle
+import com.dh.baro.product.application.dto.ProductSliceBundle
 import com.dh.baro.product.domain.service.CategoryService
 import com.dh.baro.product.domain.Product
+import com.dh.baro.product.domain.service.ProductQueryService
 import com.dh.baro.product.domain.service.ProductService
 import org.springframework.stereotype.Service
 
 @Service
 class ProductFacade(
+    private val storeService: StoreService,
     private val productService: ProductService,
+    private val productQueryService: ProductQueryService,
     private val categoryService: CategoryService,
 ) {
 
     fun createProduct(cmd: ProductCreateCommand): Product {
         val categories = categoryService.getCategoriesByIds(cmd.categoryIds)
         return productService.createProduct(cmd, categories)
+    }
+
+    fun getProductDetail(productId: Long): ProductDetailBundle {
+        val product = productQueryService.getProductDetail(productId)
+        val store = storeService.getStoreById(product.storeId)
+        return ProductDetailBundle(product, store)
+    }
+
+    fun getPopularProducts(
+        categoryId: Long?,
+        cursorLikes: Int?,
+        cursorId: Long?,
+        size: Int,
+    ): ProductSliceBundle {
+        val productSlice = productQueryService.getPopularProducts(categoryId, cursorLikes, cursorId, size)
+        val stores = storeService.getStoresByIds(productSlice.content.map { it.storeId }.toSet())
+        return ProductSliceBundle(productSlice, stores)
+    }
+
+    fun getNewestProducts(
+        categoryId: Long?,
+        cursorId: Long?,
+        size: Int,
+    ): ProductSliceBundle {
+        val productSlice = productQueryService.getNewestProducts(categoryId, cursorId, size)
+        val stores = storeService.getStoresByIds(productSlice.content.map { it.storeId }.toSet())
+        return ProductSliceBundle(productSlice, stores)
     }
 }

--- a/src/main/kotlin/com/dh/baro/product/application/dto/ProductDetailBundle.kt
+++ b/src/main/kotlin/com/dh/baro/product/application/dto/ProductDetailBundle.kt
@@ -1,0 +1,9 @@
+package com.dh.baro.product.application.dto
+
+import com.dh.baro.identity.domain.Store
+import com.dh.baro.product.domain.Product
+
+data class ProductDetailBundle (
+    val product: Product,
+    val store: Store,
+)

--- a/src/main/kotlin/com/dh/baro/product/application/dto/ProductSliceBundle.kt
+++ b/src/main/kotlin/com/dh/baro/product/application/dto/ProductSliceBundle.kt
@@ -1,0 +1,10 @@
+package com.dh.baro.product.application.dto
+
+import com.dh.baro.identity.domain.Store
+import com.dh.baro.product.domain.Product
+import org.springframework.data.domain.Slice
+
+data class ProductSliceBundle(
+    val productSlice: Slice<Product>,
+    val storeList: List<Store>,
+)

--- a/src/main/kotlin/com/dh/baro/product/presentation/ProductController.kt
+++ b/src/main/kotlin/com/dh/baro/product/presentation/ProductController.kt
@@ -4,10 +4,8 @@ import com.dh.baro.core.Cursor
 import com.dh.baro.core.ErrorMessage
 import com.dh.baro.core.SliceResponse
 import com.dh.baro.core.auth.CheckAuth
-import com.dh.baro.core.auth.CurrentUser
 import com.dh.baro.identity.domain.UserRole
 import com.dh.baro.product.application.ProductFacade
-import com.dh.baro.product.domain.service.ProductQueryService
 import com.dh.baro.product.presentation.dto.*
 import com.dh.baro.product.presentation.swagger.ProductSwagger
 import jakarta.validation.Valid
@@ -18,7 +16,6 @@ import org.springframework.web.bind.annotation.*
 @RequestMapping("/products")
 class ProductController(
     private val productFacade: ProductFacade,
-    private val productQueryService: ProductQueryService,
 ) : ProductSwagger {
 
     @PostMapping
@@ -28,6 +25,12 @@ class ProductController(
         @Valid @RequestBody request: ProductCreateRequest,
     ): ProductCreateResponse =
         ProductCreateResponse.from(productFacade.createProduct(request.toCommand()))
+
+    @GetMapping("/{productId}")
+    override fun getProductDetail(@PathVariable productId: Long): ProductDetail {
+        val productDetailBundle = productFacade.getProductDetail(productId)
+        return ProductDetail.from(productDetailBundle.product, productDetailBundle.store)
+    }
 
     @GetMapping("/popular")
     @ResponseStatus(HttpStatus.OK)
@@ -40,10 +43,12 @@ class ProductController(
         if ((cursorId == null) xor (cursorLikes == null))
             throw IllegalArgumentException(ErrorMessage.INVALID_POPULAR_PRODUCT_CURSOR.message)
 
-        val slice = productQueryService.getPopularProducts(categoryId, cursorLikes, cursorId, size)
-        return SliceResponse.from(
-            slice = slice,
-            mapper = ProductListItem::from,
+        val productSliceBundle = productFacade.getPopularProducts(categoryId, cursorLikes, cursorId, size)
+        val storeMap = productSliceBundle.storeList.associateBy { it.id }
+
+        return SliceResponse.fromNullable(
+            slice = productSliceBundle.productSlice,
+            mapper = { p -> ProductListItem.ofOrNull(p, storeMap) },
             cursorExtractor = { PopularCursor(it.id, it.getLikesCount()) },
         )
     }
@@ -55,17 +60,15 @@ class ProductController(
         @RequestParam(required = false) cursorId: Long?,
         @RequestParam(defaultValue = DEFAULT_PAGE_SIZE) size: Int,
     ): SliceResponse<ProductListItem> {
-        val slice = productQueryService.getNewestProducts(categoryId, cursorId, size)
-        return SliceResponse.from(
-            slice = slice,
-            mapper = ProductListItem::from,
+        val productSliceBundle = productFacade.getNewestProducts(categoryId, cursorId, size)
+        val storeMap = productSliceBundle.storeList.associateBy { it.id }
+
+        return SliceResponse.fromNullable(
+            slice = productSliceBundle.productSlice,
+            mapper = { p -> ProductListItem.ofOrNull(p, storeMap) },
             cursorExtractor = { Cursor(it.id) },
         )
     }
-
-    @GetMapping("/{productId}")
-    override fun getProductDetail(@PathVariable productId: Long): ProductDetail =
-        ProductDetail.from(productQueryService.getProductDetail(productId))
 
     companion object {
         private const val DEFAULT_PAGE_SIZE = "21"

--- a/src/main/kotlin/com/dh/baro/product/presentation/dto/ProductDetail.kt
+++ b/src/main/kotlin/com/dh/baro/product/presentation/dto/ProductDetail.kt
@@ -1,11 +1,13 @@
 package com.dh.baro.product.presentation.dto
 
+import com.dh.baro.identity.domain.Store
 import com.dh.baro.product.domain.Product
 import java.math.BigDecimal
 
 data class ProductDetail(
     val id: Long,
-    val name: String,
+    val storeName: String,
+    val productName: String,
     val price: BigDecimal,
     val description: String?,
     val images: List<String>,
@@ -13,9 +15,10 @@ data class ProductDetail(
 ) {
 
     companion object {
-        fun from(product: Product) = ProductDetail(
+        fun from(product: Product, store: Store) = ProductDetail(
             id = product.id,
-            name = product.getName(),
+            storeName = store.getName(),
+            productName = product.getName(),
             price = product.getPrice(),
             description = product.getDescription(),
             images = product.getImages().map { it.imageUrl },

--- a/src/main/kotlin/com/dh/baro/product/presentation/dto/ProductListItem.kt
+++ b/src/main/kotlin/com/dh/baro/product/presentation/dto/ProductListItem.kt
@@ -1,21 +1,26 @@
 package com.dh.baro.product.presentation.dto
 
+import com.dh.baro.identity.domain.Store
 import com.dh.baro.product.domain.Product
 import java.math.BigDecimal
 
 data class ProductListItem(
     val id: Long,
-    val name: String,
+    val storeName: String,
+    val productName: String,
     val price: BigDecimal,
-    val thumbnailUrl: String?,
+    val thumbnailUrl: String,
 ) {
-
     companion object {
-        fun from(product: Product) = ProductListItem(
-            id = product.id,
-            name = product.getName(),
-            price = product.getPrice(),
-            thumbnailUrl = product.getThumbnailUrl(),
-        )
+        fun ofOrNull(product: Product, storeMap: Map<Long, Store>): ProductListItem? {
+            val store = storeMap[product.storeId]?: return null
+            return ProductListItem(
+                id = product.id,
+                storeName = store.getName(),
+                productName = product.getName(),
+                price = product.getPrice(),
+                thumbnailUrl = product.getThumbnailUrl(),
+            )
+        }
     }
 }

--- a/src/main/kotlin/com/dh/baro/product/presentation/swagger/ProductSwagger.kt
+++ b/src/main/kotlin/com/dh/baro/product/presentation/swagger/ProductSwagger.kt
@@ -58,6 +58,21 @@ interface ProductSwagger {
         @RequestBody request: ProductCreateRequest,
     ): ProductCreateResponse
 
+    /* ───────────────────────────── 상품 상세 ───────────────────────────── */
+    @Operation(
+        summary = "상품 상세 보기",
+        description = "특정 상품에 대한 상세 정보를 불러옵니다.",
+        parameters = [Parameter(name = "productId", example = "11", required = true)],
+        responses = [
+            ApiResponse(
+                responseCode = "200", description = "조회 성공",
+                content = [Content(schema = Schema(implementation = ProductDetail::class))]
+            )
+        ]
+    )
+    @GetMapping("/{productId}")
+    fun getProductDetail(@PathVariable productId: Long): ProductDetail
+
     /* ───────────────────────────── 인기 상품 ───────────────────────────── */
     @Operation(
         summary = "인기 상품 목록(무한 스크롤)",
@@ -83,7 +98,7 @@ interface ProductSwagger {
                         value = """
                         {
                           "content": [
-                            { "id": 21, "name": "Sneakers", "price": 99000, "thumbnailUrl": "..." }
+                            { "id": 21, "storeName" = "무신사", "productName": "Sneakers", "price": 99000, "thumbnailUrl": "..." }
                           ],
                           "hasNext": true,
                           "nextCursor": { "id": 21, "likes": 500 }
@@ -126,7 +141,7 @@ interface ProductSwagger {
                         value = """
                         {
                           "content": [
-                            { "id": 12, "name": "Hoodie", "price": 59000, "thumbnailUrl": "..." }
+                            { "id": 12, "storeName" = "무신사", "productName": "Hoodie", "price": 59000, "thumbnailUrl": "..." }
                           ],
                           "hasNext": false,
                           "nextCursor": { "id": 11 }
@@ -143,21 +158,6 @@ interface ProductSwagger {
         @RequestParam(required = false) cursorId: Long?,
         @RequestParam(defaultValue = "21") size: Int
     ): SliceResponse<ProductListItem>
-
-    /* ───────────────────────────── 상품 상세 ───────────────────────────── */
-    @Operation(
-        summary = "상품 상세 보기",
-        description = "특정 상품에 대한 상세 정보를 불러옵니다.",
-        parameters = [Parameter(name = "productId", example = "11", required = true)],
-        responses = [
-            ApiResponse(
-                responseCode = "200", description = "조회 성공",
-                content = [Content(schema = Schema(implementation = ProductDetail::class))]
-            )
-        ]
-    )
-    @GetMapping("/{productId}")
-    fun getProductDetail(@PathVariable productId: Long): ProductDetail
 
     /* ──────────────── 예시 DTO (Swagger 문서 전용) ──────────────── */
     @Schema(hidden = true)

--- a/src/main/kotlin/com/dh/baro/product/presentation/swagger/ProductSwagger.kt
+++ b/src/main/kotlin/com/dh/baro/product/presentation/swagger/ProductSwagger.kt
@@ -98,7 +98,7 @@ interface ProductSwagger {
                         value = """
                         {
                           "content": [
-                            { "id": 21, "storeName" = "무신사", "productName": "Sneakers", "price": 99000, "thumbnailUrl": "..." }
+                            { "id": 21, "storeName": "무신사", "productName": "Sneakers", "price": 99000, "thumbnailUrl": "..." }
                           ],
                           "hasNext": true,
                           "nextCursor": { "id": 21, "likes": 500 }
@@ -141,7 +141,7 @@ interface ProductSwagger {
                         value = """
                         {
                           "content": [
-                            { "id": 12, "storeName" = "무신사", "productName": "Hoodie", "price": 59000, "thumbnailUrl": "..." }
+                            { "id": 12, "storeName": "무신사", "productName": "Hoodie", "price": 59000, "thumbnailUrl": "..." }
                           ],
                           "hasNext": false,
                           "nextCursor": { "id": 11 }

--- a/src/main/kotlin/com/dh/baro/product/presentation/swagger/ProductSwagger.kt
+++ b/src/main/kotlin/com/dh/baro/product/presentation/swagger/ProductSwagger.kt
@@ -62,7 +62,7 @@ interface ProductSwagger {
     @Operation(
         summary = "상품 상세 보기",
         description = "특정 상품에 대한 상세 정보를 불러옵니다.",
-        parameters = [Parameter(name = "productId", example = "11", required = true)],
+        parameters = [Parameter(`in` = ParameterIn.PATH, name = "productId", description = "상품 PK", example = "11", required = true)],
         responses = [
             ApiResponse(
                 responseCode = "200", description = "조회 성공",

--- a/src/test/kotlin/com/dh/baro/product/domain/ProductQueryServiceTest.kt
+++ b/src/test/kotlin/com/dh/baro/product/domain/ProductQueryServiceTest.kt
@@ -193,31 +193,5 @@ internal class ProductQueryServiceTest(
                 nextSlice.hasNext() shouldBe false
             }
         }
-
-        context("SliceResponse 변환") {
-            lateinit var response: SliceResponse<ProductListItem>
-
-            beforeTest {
-                val slice = productQueryService.getNewestProducts(
-                    categoryId = null,
-                    cursorId = null,
-                    size = 1,
-                )
-                response = SliceResponse.from(
-                    slice = slice,
-                    mapper = ProductListItem::from,
-                    cursorExtractor = { it.id },
-                )
-            }
-
-            it("content 매핑 + hasNext 필드가 올바르다") {
-                response.content.first().id shouldBe p2.id
-                response.hasNext shouldBe true
-            }
-
-            it("nextCursor 는 마지막 요소의 id 값이다") {
-                response.nextCursor shouldBe p2.id
-            }
-        }
     }
 })


### PR DESCRIPTION
## Issue Number
#20 

## As-Is

* `Look` 및 `Product` 관련 API 응답 DTO에  뷰 계층에 필요한 정보(storeName)가 누락
* `ProductController` 및 `LookFacade` 등의 클래스는 `QueryService`를 직접 호출하며 **응답 조립 책임이 분산**되어 있었음
* `Store` 정보를 활용한 응답 확장은 불가능했고, 연관된 Store 데이터를 클라이언트에서 유추할 수 없었음
* 테스트에서는 `SliceResponse.from(...)`을 포함하여 응답 변환까지 검증하고 있어 **관심사의 분리가 부족**했음

## To-Be

* 도메인에서는 **원시 값 컬렉션(List<Long>, List<String>)만 반환**하도록 리팩토링
* `LookDetailBundle`, `ProductDetailBundle`, `ProductSliceBundle` 등 응답 조립을 위한 **전용 DTO 계층 도입**
* `storeService.getStoresByIds(...)`를 활용해 **상품 응답에 storeName 포함**, 클라이언트가 스토어 정보까지 함께 수신 가능
* `ProductListItem.ofOrNull(...)` 및 `SliceResponse.fromNullable(...)`을 도입해 **store 매핑 누락 시 안전한 필터링 처리**
* `ProductController`, `LookController`는 모든 조회 기능을 `Facade`를 통해 수행하며 **표현 계층과 도메인 계층 역할 분리**
* Swagger 문서 내 예시(`popularResponse`, `newestResponse`)에 `storeName`, `productName` 반영
* 테스트에서는 `SliceResponse` 관련 변환 테스트를 제거하고 **도메인 서비스 검증에 집중**


## ✅ Check List

- [x] Have all tests passed?
- [x] Have all commits been pushed?
- [x] Did you verify the target branch for the merge?
- [x] Did you assign the appropriate assignee(s)?
- [x] Did you set the correct label(s)?

## 📸 Test Screenshot

## Additional Description
