### PR TITLE
[REFACTOR] isNew 로직 개선을 통한 불필요한 select 쿼리 제거

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ src/main/resources/application.yaml
 
 ### 개발 DB용 docker-compose 제외 ###
 /docker-compose.yaml
+
+# P6Spy log
+spy.log

--- a/src/main/kotlin/com/dh/baro/cart/domain/CartItem.kt
+++ b/src/main/kotlin/com/dh/baro/cart/domain/CartItem.kt
@@ -1,6 +1,6 @@
 package com.dh.baro.cart.domain
 
-import com.dh.baro.core.AbstractTime
+import com.dh.baro.core.BaseTimeEntity
 import com.dh.baro.core.IdGenerator
 import com.dh.baro.identity.domain.User
 import com.dh.baro.product.domain.Product
@@ -26,7 +26,9 @@ class CartItem(
 
     @Column(name = "quantity", nullable = false)
     var quantity: Int = 1
-) : AbstractTime() {
+) : BaseTimeEntity() {
+
+    override fun getId(): Long = id
 
     fun addQuantity(quantity: Int) {
         this.quantity += quantity

--- a/src/main/kotlin/com/dh/baro/cart/presentation/CartController.kt
+++ b/src/main/kotlin/com/dh/baro/cart/presentation/CartController.kt
@@ -5,8 +5,8 @@ import com.dh.baro.cart.presentation.dto.AddItemRequest
 import com.dh.baro.cart.presentation.dto.CartResponse
 import com.dh.baro.cart.presentation.dto.UpdateQuantityRequest
 import com.dh.baro.cart.presentation.swagger.CartSwagger
-import com.dh.baro.core.auth.CheckAuth
-import com.dh.baro.core.auth.CurrentUser
+import com.dh.baro.core.anotation.CheckAuth
+import com.dh.baro.core.anotation.CurrentUser
 import com.dh.baro.identity.domain.UserRole
 import jakarta.validation.Valid
 import org.springframework.http.HttpStatus

--- a/src/main/kotlin/com/dh/baro/core/BaseTimeEntity.kt
+++ b/src/main/kotlin/com/dh/baro/core/BaseTimeEntity.kt
@@ -1,25 +1,26 @@
 package com.dh.baro.core
 
-import jakarta.persistence.Column
-import jakarta.persistence.EntityListeners
-import jakarta.persistence.MappedSuperclass
-import jakarta.persistence.PrePersist
+import jakarta.persistence.*
 import org.springframework.data.annotation.CreatedDate
 import org.springframework.data.annotation.LastModifiedDate
+import org.springframework.data.domain.Persistable
 import org.springframework.data.jpa.domain.support.AuditingEntityListener
 import java.time.Instant
 
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener::class)
-abstract class AbstractTime(
+abstract class BaseTimeEntity(
     @CreatedDate
     @Column(name = "created_at", columnDefinition = "TIMESTAMP", nullable = false, updatable = false)
-    var createdAt: Instant = instant(),
+    val createdAt: Instant = instant(),
 
     @LastModifiedDate
     @Column(name = "modified_at", columnDefinition = "TIMESTAMP")
     var modifiedAt: Instant? = null,
-) {
+) : Persistable<Long> {
+
+    override fun isNew(): Boolean = (this.modifiedAt == null)
+
     @PrePersist
     fun prePersist() {
         if (modifiedAt == null) {

--- a/src/main/kotlin/com/dh/baro/core/BaseTimeEntity.kt
+++ b/src/main/kotlin/com/dh/baro/core/BaseTimeEntity.kt
@@ -12,7 +12,7 @@ import java.time.Instant
 abstract class BaseTimeEntity(
     @CreatedDate
     @Column(name = "created_at", columnDefinition = "TIMESTAMP", nullable = false, updatable = false)
-    val createdAt: Instant = instant(),
+    var createdAt: Instant = instant(),
 
     @LastModifiedDate
     @Column(name = "modified_at", columnDefinition = "TIMESTAMP")

--- a/src/main/kotlin/com/dh/baro/core/ErrorMessage.kt
+++ b/src/main/kotlin/com/dh/baro/core/ErrorMessage.kt
@@ -25,7 +25,7 @@ enum class ErrorMessage(val message: String) {
     // Product
     PRODUCT_NOT_FOUND("상품을 찾을 수 없습니다: %s"),
     INVALID_POPULAR_PRODUCT_CURSOR("cursorLikes와 cursorId는 함께 지정하거나 함께 생략해야 합니다."),
-    OUT_OF_STOCK("재고가 모두 소진되었습니다: %d"),
+    OUT_OF_STOCK("재고가 모두 소진되었습니다.[id = %d]"),
 
     // Category
     CATEGORY_ALREADY_EXISTS("카테고리(id = %d)는 이미 존재합니다."),

--- a/src/main/kotlin/com/dh/baro/core/advice/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/com/dh/baro/core/advice/GlobalExceptionHandler.kt
@@ -130,9 +130,9 @@ class GlobalExceptionHandler {
 
     @ExceptionHandler(ConflictException::class)
     @ResponseStatus(HttpStatus.CONFLICT)
-    fun handleMethodNotSupported(e: ConflictException): ErrorResponse {
+    fun handleConflict(e: ConflictException): ErrorResponse {
         logger.warn(e.message)
-        return ErrorResponse(ErrorMessage.METHOD_NOT_SUPPORTED.message)
+        return ErrorResponse.from(e)
     }
 
     // 서버가 지원하지 않는 미디어 타입

--- a/src/main/kotlin/com/dh/baro/core/anotation/AggregateRoot.kt
+++ b/src/main/kotlin/com/dh/baro/core/anotation/AggregateRoot.kt
@@ -1,4 +1,4 @@
-package com.dh.baro.core
+package com.dh.baro.core.anotation
 
 @Target(AnnotationTarget.CLASS)
 @Retention(AnnotationRetention.RUNTIME)

--- a/src/main/kotlin/com/dh/baro/core/anotation/CheckAuth.kt
+++ b/src/main/kotlin/com/dh/baro/core/anotation/CheckAuth.kt
@@ -1,4 +1,4 @@
-package com.dh.baro.core.auth
+package com.dh.baro.core.anotation
 
 import com.dh.baro.identity.domain.UserRole
 

--- a/src/main/kotlin/com/dh/baro/core/anotation/CurrentUser.kt
+++ b/src/main/kotlin/com/dh/baro/core/anotation/CurrentUser.kt
@@ -1,4 +1,4 @@
-package com.dh.baro.core.auth
+package com.dh.baro.core.anotation
 
 @Target(AnnotationTarget.VALUE_PARAMETER)
 @Retention(AnnotationRetention.RUNTIME)

--- a/src/main/kotlin/com/dh/baro/core/auth/CheckAuthAspect.kt
+++ b/src/main/kotlin/com/dh/baro/core/auth/CheckAuthAspect.kt
@@ -1,6 +1,7 @@
 package com.dh.baro.core.auth
 
 import com.dh.baro.core.ErrorMessage
+import com.dh.baro.core.anotation.CheckAuth
 import com.dh.baro.core.exception.ForbiddenException
 import com.dh.baro.identity.domain.UserRole
 import org.aspectj.lang.ProceedingJoinPoint

--- a/src/main/kotlin/com/dh/baro/core/auth/CurrentUserArgumentResolver.kt
+++ b/src/main/kotlin/com/dh/baro/core/auth/CurrentUserArgumentResolver.kt
@@ -1,5 +1,6 @@
 package com.dh.baro.core.auth
 
+import com.dh.baro.core.anotation.CurrentUser
 import org.springframework.core.MethodParameter
 import org.springframework.stereotype.Component
 import org.springframework.web.bind.support.WebDataBinderFactory

--- a/src/main/kotlin/com/dh/baro/identity/domain/SocialAccount.kt
+++ b/src/main/kotlin/com/dh/baro/identity/domain/SocialAccount.kt
@@ -1,6 +1,6 @@
 package com.dh.baro.identity.domain
 
-import com.dh.baro.core.AbstractTime
+import com.dh.baro.core.BaseTimeEntity
 import com.dh.baro.core.IdGenerator
 import jakarta.persistence.*
 
@@ -24,7 +24,9 @@ class SocialAccount(
 
     @Column(name = "provider_id", nullable = false, length = 200)
     val providerId: String
-) : AbstractTime() {
+) : BaseTimeEntity() {
+
+    override fun getId(): Long = id
 
     companion object {
         fun of(user: User, provider: AuthProvider, providerId: String): SocialAccount {

--- a/src/main/kotlin/com/dh/baro/identity/domain/Store.kt
+++ b/src/main/kotlin/com/dh/baro/identity/domain/Store.kt
@@ -1,6 +1,6 @@
 package com.dh.baro.identity.domain
 
-import com.dh.baro.core.AbstractTime
+import com.dh.baro.core.BaseTimeEntity
 import com.dh.baro.core.IdGenerator
 import jakarta.persistence.*
 
@@ -34,7 +34,9 @@ class Store(
     @Enumerated(EnumType.STRING)
     @Column(name = "store_status", nullable = false, length = 20)
     private var status: StoreStatus = StoreStatus.DRAFT,
-) : AbstractTime() {
+) : BaseTimeEntity() {
+
+    override fun getId(): Long = id
 
     fun getName(): String = name
 

--- a/src/main/kotlin/com/dh/baro/identity/domain/User.kt
+++ b/src/main/kotlin/com/dh/baro/identity/domain/User.kt
@@ -1,6 +1,6 @@
 package com.dh.baro.identity.domain
 
-import com.dh.baro.core.AbstractTime
+import com.dh.baro.core.BaseTimeEntity
 import com.dh.baro.core.IdGenerator
 import com.dh.baro.core.anotation.AggregateRoot
 import jakarta.persistence.*
@@ -36,7 +36,9 @@ class User(
         orphanRemoval = true,
     )
     private val socialAccounts: MutableList<SocialAccount> = mutableListOf(),
-) : AbstractTime() {
+) : BaseTimeEntity() {
+
+    override fun getId(): Long = id
 
     fun getName() = name
 

--- a/src/main/kotlin/com/dh/baro/identity/domain/User.kt
+++ b/src/main/kotlin/com/dh/baro/identity/domain/User.kt
@@ -2,7 +2,7 @@ package com.dh.baro.identity.domain
 
 import com.dh.baro.core.AbstractTime
 import com.dh.baro.core.IdGenerator
-import com.dh.baro.core.AggregateRoot
+import com.dh.baro.core.anotation.AggregateRoot
 import jakarta.persistence.*
 
 @AggregateRoot

--- a/src/main/kotlin/com/dh/baro/identity/presentation/UserController.kt
+++ b/src/main/kotlin/com/dh/baro/identity/presentation/UserController.kt
@@ -1,7 +1,7 @@
 package com.dh.baro.identity.presentation
 
-import com.dh.baro.core.auth.CurrentUser
-import com.dh.baro.core.auth.CheckAuth
+import com.dh.baro.core.anotation.CurrentUser
+import com.dh.baro.core.anotation.CheckAuth
 import com.dh.baro.identity.application.UserFacade
 import com.dh.baro.identity.domain.UserRole
 import com.dh.baro.identity.presentation.dto.UserProfileResponse

--- a/src/main/kotlin/com/dh/baro/look/domain/Look.kt
+++ b/src/main/kotlin/com/dh/baro/look/domain/Look.kt
@@ -1,6 +1,6 @@
 package com.dh.baro.look.domain
 
-import com.dh.baro.core.AbstractTime
+import com.dh.baro.core.BaseTimeEntity
 import com.dh.baro.core.anotation.AggregateRoot
 import com.dh.baro.core.IdGenerator
 import jakarta.persistence.*
@@ -44,7 +44,9 @@ class Look(
         orphanRemoval = true,
     )
     private val products: MutableSet<LookProduct> = mutableSetOf(),
-) : AbstractTime() {
+) : BaseTimeEntity() {
+
+    override fun getId(): Long = id
 
     fun getTitle() = title
 

--- a/src/main/kotlin/com/dh/baro/look/domain/Look.kt
+++ b/src/main/kotlin/com/dh/baro/look/domain/Look.kt
@@ -1,7 +1,7 @@
 package com.dh.baro.look.domain
 
 import com.dh.baro.core.AbstractTime
-import com.dh.baro.core.AggregateRoot
+import com.dh.baro.core.anotation.AggregateRoot
 import com.dh.baro.core.IdGenerator
 import jakarta.persistence.*
 

--- a/src/main/kotlin/com/dh/baro/look/domain/LookImage.kt
+++ b/src/main/kotlin/com/dh/baro/look/domain/LookImage.kt
@@ -1,6 +1,6 @@
 package com.dh.baro.look.domain
 
-import com.dh.baro.core.AbstractTime
+import com.dh.baro.core.BaseTimeEntity
 import com.dh.baro.core.IdGenerator
 import jakarta.persistence.*
 
@@ -20,7 +20,9 @@ class LookImage(
 
     @Column(name = "display_order", nullable = false)
     val displayOrder: Int,
-) : AbstractTime() {
+) : BaseTimeEntity() {
+
+    override fun getId(): Long = id
 
     companion object {
         fun of(

--- a/src/main/kotlin/com/dh/baro/look/domain/LookReaction.kt
+++ b/src/main/kotlin/com/dh/baro/look/domain/LookReaction.kt
@@ -1,6 +1,6 @@
 package com.dh.baro.look.domain
 
-import com.dh.baro.core.AbstractTime
+import com.dh.baro.core.BaseTimeEntity
 import com.dh.baro.core.IdGenerator
 import jakarta.persistence.*
 
@@ -23,7 +23,9 @@ class LookReaction(
     @Enumerated(EnumType.STRING)
     @Column(name = "reaction_type", nullable = false, length = 10)
     val reactionType: ReactionType,
-) : AbstractTime() {
+) : BaseTimeEntity() {
+
+    override fun getId(): Long = id
 
     companion object {
         fun of(

--- a/src/main/kotlin/com/dh/baro/look/presentation/LookController.kt
+++ b/src/main/kotlin/com/dh/baro/look/presentation/LookController.kt
@@ -2,7 +2,7 @@ package com.dh.baro.look.presentation
 
 import com.dh.baro.core.Cursor
 import com.dh.baro.core.SliceResponse
-import com.dh.baro.core.auth.CurrentUser
+import com.dh.baro.core.anotation.CurrentUser
 import com.dh.baro.look.application.LookFacade
 import com.dh.baro.look.application.LookReactionFacade
 import com.dh.baro.look.presentation.dto.*

--- a/src/main/kotlin/com/dh/baro/order/domain/Order.kt
+++ b/src/main/kotlin/com/dh/baro/order/domain/Order.kt
@@ -1,7 +1,7 @@
 package com.dh.baro.order.domain
 
 import com.dh.baro.core.AbstractTime
-import com.dh.baro.core.AggregateRoot
+import com.dh.baro.core.anotation.AggregateRoot
 import com.dh.baro.core.IdGenerator
 import jakarta.persistence.*
 import java.math.BigDecimal

--- a/src/main/kotlin/com/dh/baro/order/domain/Order.kt
+++ b/src/main/kotlin/com/dh/baro/order/domain/Order.kt
@@ -1,8 +1,8 @@
 package com.dh.baro.order.domain
 
-import com.dh.baro.core.AbstractTime
-import com.dh.baro.core.anotation.AggregateRoot
+import com.dh.baro.core.BaseTimeEntity
 import com.dh.baro.core.IdGenerator
+import com.dh.baro.core.anotation.AggregateRoot
 import jakarta.persistence.*
 import java.math.BigDecimal
 import java.math.RoundingMode
@@ -34,8 +34,10 @@ class Order(
         cascade = [CascadeType.ALL],
         orphanRemoval = true,
     )
-    val items: MutableSet<OrderItem> = mutableSetOf()
-) : AbstractTime() {
+    val items: MutableSet<OrderItem> = mutableSetOf(),
+) : BaseTimeEntity() {
+
+    override fun getId(): Long = id
 
     fun addItem(item: OrderItem) =
         items.add(item)

--- a/src/main/kotlin/com/dh/baro/order/domain/OrderItem.kt
+++ b/src/main/kotlin/com/dh/baro/order/domain/OrderItem.kt
@@ -1,6 +1,6 @@
 package com.dh.baro.order.domain
 
-import com.dh.baro.core.AbstractTime
+import com.dh.baro.core.BaseTimeEntity
 import com.dh.baro.core.IdGenerator
 import com.dh.baro.product.domain.Product
 import jakarta.persistence.*
@@ -26,7 +26,9 @@ class OrderItem(
 
     @Column(name = "price_at_purchase", nullable = false, precision = 10, scale = 0)
     val priceAtPurchase: BigDecimal,
-) : AbstractTime() {
+) : BaseTimeEntity() {
+
+    override fun getId(): Long = id
 
     fun subTotal(): BigDecimal =
         priceAtPurchase.multiply(quantity.toBigDecimal())

--- a/src/main/kotlin/com/dh/baro/order/presentation/OrderController.kt
+++ b/src/main/kotlin/com/dh/baro/order/presentation/OrderController.kt
@@ -2,7 +2,7 @@ package com.dh.baro.order.presentation
 
 import com.dh.baro.core.Cursor
 import com.dh.baro.core.SliceResponse
-import com.dh.baro.core.auth.CurrentUser
+import com.dh.baro.core.anotation.CurrentUser
 import com.dh.baro.order.application.OrderFacade
 import com.dh.baro.order.application.OrderQueryFacade
 import com.dh.baro.order.presentation.swagger.OrderSwagger

--- a/src/main/kotlin/com/dh/baro/product/domain/Product.kt
+++ b/src/main/kotlin/com/dh/baro/product/domain/Product.kt
@@ -1,7 +1,7 @@
 package com.dh.baro.product.domain
 
 import com.dh.baro.core.AbstractTime
-import com.dh.baro.core.AggregateRoot
+import com.dh.baro.core.anotation.AggregateRoot
 import com.dh.baro.core.ErrorMessage
 import com.dh.baro.core.IdGenerator
 import com.dh.baro.core.exception.ConflictException

--- a/src/main/kotlin/com/dh/baro/product/domain/Product.kt
+++ b/src/main/kotlin/com/dh/baro/product/domain/Product.kt
@@ -1,6 +1,6 @@
 package com.dh.baro.product.domain
 
-import com.dh.baro.core.AbstractTime
+import com.dh.baro.core.BaseTimeEntity
 import com.dh.baro.core.anotation.AggregateRoot
 import com.dh.baro.core.ErrorMessage
 import com.dh.baro.core.IdGenerator
@@ -53,7 +53,9 @@ class Product(
         fetch = FetchType.LAZY
     )
     private val productCategories: MutableSet<ProductCategory> = mutableSetOf(),
-) : AbstractTime() {
+) : BaseTimeEntity() {
+
+    override fun getId(): Long = id
 
     fun getName(): String = name
 

--- a/src/main/kotlin/com/dh/baro/product/domain/ProductImage.kt
+++ b/src/main/kotlin/com/dh/baro/product/domain/ProductImage.kt
@@ -1,6 +1,6 @@
 package com.dh.baro.product.domain
 
-import com.dh.baro.core.AbstractTime
+import com.dh.baro.core.BaseTimeEntity
 import com.dh.baro.core.IdGenerator
 import jakarta.persistence.*
 
@@ -20,7 +20,9 @@ class ProductImage(
 
     @Column(name = "display_order", nullable = false)
     val displayOrder: Int,
-) : AbstractTime() {
+) : BaseTimeEntity() {
+
+    override fun getId(): Long = id
 
     companion object {
         fun of(

--- a/src/main/kotlin/com/dh/baro/product/domain/ProductLike.kt
+++ b/src/main/kotlin/com/dh/baro/product/domain/ProductLike.kt
@@ -1,6 +1,6 @@
 package com.dh.baro.product.domain
 
-import com.dh.baro.core.AbstractTime
+import com.dh.baro.core.BaseTimeEntity
 import jakarta.persistence.*
 
 @Entity
@@ -15,4 +15,8 @@ class ProductLike(
 
     @Column(name = "product_id", nullable = false)
     val productId: Long,
-) : AbstractTime()
+) : BaseTimeEntity() {
+
+    override fun getId(): Long = id
+
+}

--- a/src/main/kotlin/com/dh/baro/product/presentation/CategoryController.kt
+++ b/src/main/kotlin/com/dh/baro/product/presentation/CategoryController.kt
@@ -1,6 +1,6 @@
 package com.dh.baro.product.presentation
 
-import com.dh.baro.core.auth.CheckAuth
+import com.dh.baro.core.anotation.CheckAuth
 import com.dh.baro.identity.domain.UserRole
 import com.dh.baro.product.application.CategoryFacade
 import com.dh.baro.product.presentation.dto.CategoryCreateRequest

--- a/src/main/kotlin/com/dh/baro/product/presentation/ProductController.kt
+++ b/src/main/kotlin/com/dh/baro/product/presentation/ProductController.kt
@@ -3,7 +3,7 @@ package com.dh.baro.product.presentation
 import com.dh.baro.core.Cursor
 import com.dh.baro.core.ErrorMessage
 import com.dh.baro.core.SliceResponse
-import com.dh.baro.core.auth.CheckAuth
+import com.dh.baro.core.anotation.CheckAuth
 import com.dh.baro.identity.domain.UserRole
 import com.dh.baro.product.application.ProductFacade
 import com.dh.baro.product.presentation.dto.*


### PR DESCRIPTION
## Issue Number
#23 

## As-Is
<!-- Describe the current issue or problem -->

* `AbstractTime`에서는 `createdAt`에 기본값으로 `Instant.now()`를 할당하여 null을 허용하지 않도록 처리함
* 이로 인해 JPA의 `Persistable.isNew()` 구현 시 `createdAt`으로는 신규 여부를 판별할 수 없어 활용하지 않음
* 엔티티 식별자를 직접 할당하는 구조에서는 JPA가 `save()` 시 `isNew()`를 false로 판단하여 `merge()`를 수행하고, 그에 따라 불필요한 `select` 쿼리가 발생함

## To-Be
<!-- Describe the intended changes or improvements -->

* `BaseTimeEntity`로 클래스명을 변경하고 `Persistable<Long>`을 구현하여 `isNew()`를 명시적으로 제어
* `isNew()`는 `modifiedAt == null`일 때만 true를 반환하도록 구현
* `@PrePersist`를 통해 최초 저장 시점에 `modifiedAt`에 `createdAt` 값을 복사하여 이후 `isNew()` 체크를 피하도록 설계
* 결과적으로 `save()` 시 JPA가 `persist()`를 수행하게 되어 불필요한 `select` 쿼리를 제거하고 성능을 최적화함


## ✅ Check List

- [ ] Have all tests passed?
- [ ] Have all commits been pushed?
- [ ] Did you verify the target branch for the merge?
- [ ] Did you assign the appropriate assignee(s)?
- [ ] Did you set the correct label(s)?

## 📸 Test Screenshot

## Additional Description
