### PR TITLE
[REFACTOR] update 기반 재고 차감 로직 도입으로 X-Lock 보유 시간 최소화

### DIFF
--- a/src/main/kotlin/com/dh/baro/order/application/OrderFacade.kt
+++ b/src/main/kotlin/com/dh/baro/order/application/OrderFacade.kt
@@ -15,6 +15,6 @@ class OrderFacade(
     fun placeOrder(userId: Long, request: OrderCreateRequest): Order {
         userService.getUserById(userId)
         val cmd = OrderCreateCommand.toCommand(userId, request)
-        return orderService.createOrder(cmd)
+        return orderService.createOrderV2(cmd)
     }
 }

--- a/src/main/kotlin/com/dh/baro/order/domain/OrderService.kt
+++ b/src/main/kotlin/com/dh/baro/order/domain/OrderService.kt
@@ -3,22 +3,32 @@ package com.dh.baro.order.domain
 import com.dh.baro.core.ErrorMessage
 import com.dh.baro.order.application.OrderCreateCommand
 import com.dh.baro.product.domain.repository.ProductRepository
+import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
 @Service
-@Transactional(readOnly = true)
+@Transactional
 class OrderService(
     private val productRepository: ProductRepository,
     private val orderRepository: OrderRepository,
 ) {
 
-    @Transactional
     fun createOrder(cmd: OrderCreateCommand): Order {
         val order = Order.newOrder(cmd.userId, cmd.shippingAddress)
 
         val mergedItems = mergeDuplicateItems(cmd.items)
         mergedItems.forEach { addItemsToOrder(it, order) }
+        order.updateTotalPrice()
+
+        return orderRepository.save(order)
+    }
+
+    fun createOrderV2(cmd: OrderCreateCommand): Order {
+        val order = Order.newOrder(cmd.userId, cmd.shippingAddress)
+
+        val mergedItems = mergeDuplicateItems(cmd.items)
+        mergedItems.forEach { addItemsToOrderV2(it, order) }
         order.updateTotalPrice()
 
         return orderRepository.save(order)
@@ -39,6 +49,20 @@ class OrderService(
             ?: throw IllegalArgumentException(ErrorMessage.PRODUCT_NOT_FOUND.format(item.productId))
 
         product.deductStockForOrder(item.quantity)
+
+        val orderItem = OrderItem.newOrderItem(
+            order = order,
+            product = product,
+            quantity = item.quantity,
+        )
+        order.addItem(orderItem)
+    }
+
+    private fun addItemsToOrderV2(item: OrderCreateCommand.Item, order: Order) {
+        productRepository.deductStock(item.productId, item.quantity)
+
+        val product = productRepository.findByIdOrNull(item.productId)
+            ?: throw IllegalArgumentException(ErrorMessage.PRODUCT_NOT_FOUND.format(item.productId))
 
         val orderItem = OrderItem.newOrderItem(
             order = order,

--- a/src/main/kotlin/com/dh/baro/product/domain/repository/ProductRepository.kt
+++ b/src/main/kotlin/com/dh/baro/product/domain/repository/ProductRepository.kt
@@ -6,6 +6,7 @@ import org.springframework.data.domain.Pageable
 import org.springframework.data.domain.Slice
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Lock
+import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
 import java.time.Instant
@@ -15,6 +16,17 @@ interface ProductRepository : JpaRepository<Product, Long> {
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("select p from Product p where p.id = :id")
     fun findByIdForUpdate(@Param("id") id: Long): Product?
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+        UPDATE Product p 
+        SET p.quantity = p.quantity - :quantity 
+        WHERE p.id = :id AND p.quantity >= :quantity
+    """)
+    fun deductStock(
+        @Param("id") id: Long,
+        @Param("quantity") quantity: Int,
+    ): Int
 
     @Query("""
         select p from Product p


### PR DESCRIPTION
## Issue Number
#25 

## As-Is
<!-- Describe the current issue or problem -->
* 주문 생성 시, 재고 차감을 위해 `ProductRepository.findByIdForUpdate()`를 사용하여 **비관적 락(PESSIMISTIC\_WRITE)** 기반으로 상품을 조회
* 이후 도메인 내부에서 `product.deductStockForOrder(quantity)` 호출로 재고를 차감
* 이 방식은 X-Lock을 잡은 상태에서 영속성 컨텍스트에 반영 → **트랜잭션 내에서 락 보유 시간이 길어지는 문제** 발생
* 특히 다수 상품을 주문할 경우 **락 경합과 데드락 가능성** 존재

## To-Be
<!-- Describe the intended changes or improvements -->
* **update 기반 비관적 락을 통한 원자적 재고 감소 처리의 `createOrderV2` 메서드 추가**
* `ProductRepository.deductStock()`을 통해 **재고 차감을 먼저 DB에 반영**하고, 이후 `findByIdOrNull()`로 상품 정보를 조회
* 트랜잭션 내에서 **X-Lock 유지 시간을 최소화**하고, 높은 동시성 상황에서 **성능 병목 개선 기대**

## ✅ Check List

- [ ] Have all tests passed?
- [ ] Have all commits been pushed?
- [ ] Did you verify the target branch for the merge?
- [ ] Did you assign the appropriate assignee(s)?
- [ ] Did you set the correct label(s)?

## 📸 Test Screenshot

## Additional Description
